### PR TITLE
docs: formatting classes and methods names for better lisibility

### DIFF
--- a/.vscode/extension.bat
+++ b/.vscode/extension.bat
@@ -1,8 +1,8 @@
-@REM This section install VSCode extensions for PySam Developers
+@REM This section install VSCode extensions for PySAM SysML2 Developers
 call code --install-extension donjayamanne.python-extension-pack
 call code --install-extension ms-python.black-formatter
 call code --install-extension ms-python.flake8
 call code --install-extension ms-python.isort
 call code --install-extension sonarsource.sonarlint-vscode
-@REM This section install Python dependencies for PySam developers
+@REM This section install Python dependencies for PySAM SysML2 developers
 pip install -r requirements.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,4 +23,4 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
 }
-// This settings.json is the base config VScode for PySam developers
+// This settings.json is the base config VScode for PySAM SysML2 developers

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# This is the list of pysam-sysml2's significant contributors.
+# This is the list of PySAM SysML2's significant contributors.
 #
 # This file does not necessarily list everyone who has contributed code.
 #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,6 @@
 Overall guidance on contributing to a PyAnsys library appears in the
 [Contributing] topic in the *PyAnsys developer's guide*. Ensure that you
 are thoroughly familiar with this guide before attempting to contribute to
-PySam.
+PySAM SysML2.
 
 [Contributing]: https://dev.docs.pyansys.com/how-to/contributing.html

--- a/doc/source/_static/code/simplified-sam-project.py
+++ b/doc/source/_static/code/simplified-sam-project.py
@@ -1,4 +1,4 @@
-"""AnsysSysML2Project Example for PySam."""
+"""AnsysSysML2Project Example for PySAM SysML2."""
 
 import requests
 from urllib3.exceptions import InsecureRequestWarning

--- a/doc/source/_static/code/weight-bike.py
+++ b/doc/source/_static/code/weight-bike.py
@@ -1,4 +1,4 @@
-"""Weight Bike Example for PySam."""
+"""Weight Bike Example for PySAM SysML2."""
 
 # Import connector and model manager
 import requests

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -1,7 +1,8 @@
 API reference
 =============
 
-This section describes PySAM SysML2 functions, classes, and methods.
+This section describes ansys-sam-sysml2 endpoints, their capabilities, and how
+to interact with them programmatically.
 
 .. toctree::
    :titlesonly:

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -1,8 +1,7 @@
 API reference
 =============
 
-This section describes ansys-sam-sysml2 endpoints, their capabilities, and how
-to interact with them programmatically.
+This section describes how to interact with the PySAM SysML2 API programmatically.
 
 .. toctree::
    :titlesonly:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -84,7 +84,7 @@ latex_additional_files = [
     pyansys_logo_black,
 ]
 latex_elements = {
-    "preamble": (generate_preamble("PySam", watermark)),
+    "preamble": (generate_preamble("PySAM SysML2", watermark)),
     "printindex": "",
 }
 

--- a/doc/source/examples/bike-weight.rst
+++ b/doc/source/examples/bike-weight.rst
@@ -53,7 +53,7 @@ After logging in, load the ``bike`` project.
     :language: python
     :caption: Load the bike project
 
-For more information about the project object, see :class:`ansys.sam.sysml2.classes.project.Project` in the API reference documentation.
+For more information about the project object, see :class:`Project <ansys.sam.sysml2.classes.project.Project>` in the API reference documentation.
 
 Step 2: Calculate bike weight
 -----------------------------

--- a/doc/source/examples/bike-weight.rst
+++ b/doc/source/examples/bike-weight.rst
@@ -13,7 +13,8 @@ Download the bike model used in this example and import it into a new project to
 
 #. Select **Choose File** for the **File to import** option.
 
-#. Select the ``bike.xmi`` file that you just downloaded. The project name is automatically set to ``bike``.
+#. Select the ``bike.xmi`` file that you just downloaded. The project name is automatically set to
+   ``bike``.
 
 #. Click **Import** and wait for the project to load.
 
@@ -22,7 +23,8 @@ You can now work on this bike model.
 Calculate weight
 ~~~~~~~~~~~~~~~~
 
-The bike weight is the sum of the frame weight and the weight of all wheel component elements. Thus, you want to calculate the sum of all blue elements in the model:
+The bike weight is the sum of the frame weight and the weight of all wheel component elements.
+Thus, you want to calculate the sum of all blue elements in the model:
 
 .. figure:: /_static/images/weight-bike.png
 
@@ -31,11 +33,13 @@ Step 1: Load the project
 
 .. note::
 
-    Ensure that you have installed PySAM SysML2. If not, see :ref:`Installation <Installation_Section>`.
+    Ensure that you have installed PySAM SysML2. If not, see
+    :ref:`Installation <Installation_Section>`.
 
 Before loading the project, create a connector and a project manager.
 
-To obtain the required data, see :ref:`Find organization ID <Info_O_Id_Section>` and :ref:`Find bearer token <Info_B_Token_Section>`.
+To obtain the required data, see :ref:`Find organization ID <Info_O_Id_Section>` and
+:ref:`Find bearer token <Info_B_Token_Section>`.
 
 .. literalinclude:: ../_static/code/weight-bike.py
     :lines: 3-18
@@ -53,12 +57,14 @@ After logging in, load the ``bike`` project.
     :language: python
     :caption: Load the bike project
 
-For more information about the project object, see :class:`Project <ansys.sam.sysml2.classes.project.Project>` in the API reference documentation.
+For more information about the project object, see
+:class:`Project <ansys.sam.sysml2.classes.project.Project>` in the API reference documentation.
 
 Step 2: Calculate bike weight
 -----------------------------
 
-After loading the project, get the ``Bike`` element. As explained in :ref:`Access methods <Getter>`, there are many ways to get an element. This code uses dot notation:
+After loading the project, get the ``Bike`` element. As explained in
+:ref:`Access methods <Getter>`, there are many ways to get an element. This code uses dot notation:
 
 .. literalinclude:: ../_static/code/weight-bike.py
     :lines: 26

--- a/doc/source/examples/bike-weight.rst
+++ b/doc/source/examples/bike-weight.rst
@@ -31,7 +31,7 @@ Step 1: Load the project
 
 .. note::
 
-    Ensure that you have installed PySam SysML. If not, see :ref:`Installation <Installation_Section>`.
+    Ensure that you have installed PySAM SysML2. If not, see :ref:`Installation <Installation_Section>`.
 
 Before loading the project, create a connector and a project manager.
 

--- a/doc/source/examples/computer-cost.rst
+++ b/doc/source/examples/computer-cost.rst
@@ -13,7 +13,8 @@ Download the computer model used in this example and import it into a new projec
 
 #. Select **Choose File** for the **File to import** option.
 
-#. Select the ``computer.xmi`` file that you just downloaded. The project name is automatically set to ``computer``.
+#. Select the ``computer.xmi`` file that you just downloaded. The project name is automatically
+   set to ``computer``.
 
 #. Click **Import** and wait for the project to load.
 
@@ -25,7 +26,8 @@ Calculate cost
 
 .. note::
 
-    You need to replace the organization ID, server URL, and token with your own data. For more information, see :ref:`Find information<Info_Section>`.
+    You need to replace the organization ID, server URL, and token with your own data. For more
+    information, see :ref:`Find information<Info_Section>`.
 
 .. literalinclude:: ../_static/code/computer-cost.py
     :language: python

--- a/doc/source/examples/creating-elements.rst
+++ b/doc/source/examples/creating-elements.rst
@@ -3,7 +3,8 @@
 Create a new element
 ####################
 
-Make sure that you have access to a valid server and a project containing the ``Bike`` structure. If you do not have a project containing the ``Bike`` structure, perform the following steps:
+Make sure that you have access to a valid server and a project containing the ``Bike`` structure.
+If you do not have a project containing the ``Bike`` structure, perform the following steps:
 
 #. Download the model: :download:`Bike Model <../_static/code/bike.xmi>`.
 
@@ -13,7 +14,8 @@ Make sure that you have access to a valid server and a project containing the ``
 
 #. Select **Choose File** for the **File to import** option.
 
-#. Select the ``bike.xmi`` file that you just downloaded. The project name is automatically set to ``bike``.
+#. Select the ``bike.xmi`` file that you just downloaded. The project name is automatically set to
+   ``bike``.
 
 #. Click **Import** and wait for the project to load.
 
@@ -22,11 +24,13 @@ Create an attribute usage element for the bicycle frame length
 
 .. currentmodule:: ansys.sam.sysml2.tools.factory
 
-The following code shows how to create a new ``AttributeUsage`` element inside the ``Bike`` structure and assign it a value.
+The following code shows how to create a new ``AttributeUsage`` element inside the ``Bike``
+structure and assign it a value.
 
 .. note::
 
-    You need to replace the organization ID, server URL, and token with your own data. For more information, see :ref:`Find information<Info_Section>`.
+    You need to replace the organization ID, server URL, and token with your own data. For more
+    information, see :ref:`Find information<Info_Section>`.
 
 .. literalinclude:: ../_static/code/creating-elements.py
     :language: python
@@ -39,7 +43,10 @@ You just created a new element and assigned a parsed value to it.
 
 .. note::
 
-    You can also assign a value directly when creating the element, without using the :meth:`set_value() <SysMLElement.set_value>` or :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>` method. There are two ways:
+    You can also assign a value directly when creating the element, without using the 
+    :meth:`set_value() <SysMLElement.set_value>` or
+    :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>`
+    method. There are two ways:
 
     - ``value=...`` for simple values (such as numbers).
     - ``expression="..."`` for values with units or expressions.

--- a/doc/source/examples/creating-elements.rst
+++ b/doc/source/examples/creating-elements.rst
@@ -20,6 +20,8 @@ Make sure that you have access to a valid server and a project containing the ``
 Create an attribute usage element for the bicycle frame length
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: ansys.sam.sysml2.tools.factory
+
 The following code shows how to create a new ``AttributeUsage`` element inside the ``Bike`` structure and assign it a value.
 
 .. note::
@@ -28,14 +30,16 @@ The following code shows how to create a new ``AttributeUsage`` element inside t
 
 .. literalinclude:: ../_static/code/creating-elements.py
     :language: python
-    :caption: Create a new AttributeUsage element using the Factory class
+    :caption: Create a new AttributeUsage element using the :class:`Factory` class
     :linenos:
 
 You just created a new element and assigned a parsed value to it.
 
+.. currentmodule:: ansys.sam.sysml2.classes.sysml_element
+
 .. note::
 
-    You can also assign a value directly when creating the element, without using the ``set_value()`` or ``parse_and_set_value()`` method. There are two ways:
+    You can also assign a value directly when creating the element, without using the :meth:`set_value() <SysMLElement.set_value>` or :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>` method. There are two ways:
 
     - ``value=...`` for simple values (such as numbers).
     - ``expression="..."`` for values with units or expressions.

--- a/doc/source/examples/creating-elements.rst
+++ b/doc/source/examples/creating-elements.rst
@@ -43,7 +43,7 @@ You just created a new element and assigned a parsed value to it.
 
 .. note::
 
-    You can also assign a value directly when creating the element, without using the 
+    You can also assign a value directly when creating the element, without using the
     :meth:`set_value() <SysMLElement.set_value>` or
     :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>`
     method. There are two ways:

--- a/doc/source/examples/download-diagrams.rst
+++ b/doc/source/examples/download-diagrams.rst
@@ -3,14 +3,16 @@
 Download diagrams and create new elements
 #########################################
 
-This example shows how to work with the ``Bike`` model in a SysML v2 project using the Ansys SAM API. It explains how to perform these tasks:
+This example shows how to work with the ``Bike`` model in a SysML v2 project using the
+Ansys SAM API. It explains how to perform these tasks:
 
 - Load and download diagrams.
 - Navigate and save diagram content.
 
 .. note::
 
-    If you have never used PySAM SysML2 before, start with one of these simpler examples to understand how this library works:
+    If you have never used PySAM SysML2 before, start with one of these simpler examples to
+    understand how this library works:
 
     - :ref:`Calculate bike weight<Bike_Example>`
     - :ref:`Calculate computer cost<Computer_Example>`
@@ -35,5 +37,7 @@ Python example
 .. note::
 
     - Replace placeholder values with your actual SAM configuration.
-    - Always use the :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>` class within a context manager (``with`` statement).
+    - Always use the
+      :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>`
+      class within a context manager (``with`` statement).
     - Retrieve diagram content in various formats, such as ``png`` and ``svg``.

--- a/doc/source/examples/download-diagrams.rst
+++ b/doc/source/examples/download-diagrams.rst
@@ -35,5 +35,5 @@ Python example
 .. note::
 
     - Replace placeholder values with your actual SAM configuration.
-    - Always use the ``SAMDiagramManager`` class within a context manager (``with`` statement).
+    - Always use the :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>` class within a context manager (``with`` statement).
     - Retrieve diagram content in various formats, such as ``png`` and ``svg``.

--- a/doc/source/examples/simplified-sam-project.rst
+++ b/doc/source/examples/simplified-sam-project.rst
@@ -52,12 +52,16 @@ offers these advantages:
 
 - **Single initialization**: One class automatically handles all connectors.
 - **Built-in diagram management**: Removes the need to manually create and manage the
-  :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>` class.
-- **Streamlined API**: Provides direct access to project operations without managing multiple connector instances.
-- **Integrated features**: Combines project management, diagram operations, and element creation in one interface.
+  :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>`
+  class.
+- **Streamlined API**: Provides direct access to project operations without managing multiple
+  connector instances.
+- **Integrated features**: Combines project management, diagram operations, and element creation in
+  one interface.
 
 .. note::
 
   - Replace placeholder values with your actual SAM configuration.
-  - The :class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` class automatically manages diagram loading and the connector lifecycle.
+  - The :class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>`
+    class automatically manages diagram loading and the connector lifecycle.
   - The class supports all diagram formats (``png``, ``svg``, ``jpeg``) for downloads.

--- a/doc/source/examples/simplified-sam-project.rst
+++ b/doc/source/examples/simplified-sam-project.rst
@@ -20,10 +20,11 @@ initializing all necessary connectors. It explains how to perform these tasks:
     :class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>`
     class is specifically designed for SAM projects and automatically handles the initialization
     of these classes:
-    :class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`,
-    :class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>`,
-    :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>`,
-    and :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>`.
+
+    - :class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`,
+    - :class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>`,
+    - :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>`,
+    - :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>`.
 
 Prerequisites for simplified SAM
 ================================

--- a/doc/source/examples/simplified-sam-project.rst
+++ b/doc/source/examples/simplified-sam-project.rst
@@ -4,8 +4,9 @@ Simplify SAM project initialization
 ###################################
 
 This example shows how to use the simplified
-:class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` class to work with a SysML v2 project on SAM. This approach reduces boilerplate code by automatically initializing all
-necessary connectors. It explains how to perform these tasks:
+:class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` class
+to work with a SysML v2 project on SAM. This approach reduces boilerplate code by automatically
+initializing all necessary connectors. It explains how to perform these tasks:
 
 - Simplify project initialization with a single class.
 - Download diagrams (single and batch).
@@ -15,8 +16,14 @@ necessary connectors. It explains how to perform these tasks:
 
 .. note::
 
-    The :class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` class is specifically designed for SAM projects and automatically handles the initialization of these classes: :class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`, :class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>`,
-    :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>`, and :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>`.
+    The
+    :class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>`
+    class is specifically designed for SAM projects and automatically handles the initialization
+    of these classes:
+    :class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`,
+    :class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>`,
+    :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>`,
+    and :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>`.
 
 Prerequisites for simplified SAM
 ================================
@@ -38,11 +45,14 @@ Simplified Python example
 Key advantages
 ==============
 
-Compared to the traditional approach described in :ref:`Download diagrams and create new elements<Download_Example>`, using the simplified
-:class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` class offers these advantages:
+Compared to the traditional approach described in
+:ref:`Download diagrams and create new elements<Download_Example>`, using the simplified
+:class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` class
+offers these advantages:
 
 - **Single initialization**: One class automatically handles all connectors.
-- **Built-in diagram management**: Removes the need to manually create and manage the :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>` class.
+- **Built-in diagram management**: Removes the need to manually create and manage the
+  :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>` class.
 - **Streamlined API**: Provides direct access to project operations without managing multiple connector instances.
 - **Integrated features**: Combines project management, diagram operations, and element creation in one interface.
 

--- a/doc/source/examples/simplified-sam-project.rst
+++ b/doc/source/examples/simplified-sam-project.rst
@@ -4,7 +4,7 @@ Simplify SAM project initialization
 ###################################
 
 This example shows how to use the simplified
-:class:`ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project` class to work with a SysML v2 project on SAM. This approach reduces boilerplate code by automatically initializing all
+:class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` class to work with a SysML v2 project on SAM. This approach reduces boilerplate code by automatically initializing all
 necessary connectors. It explains how to perform these tasks:
 
 - Simplify project initialization with a single class.
@@ -15,8 +15,8 @@ necessary connectors. It explains how to perform these tasks:
 
 .. note::
 
-    The ``AnsysSysML2Project`` class is specifically designed for SAM projects and automatically handles the initialization of these classes: ``AnsysSysML2APIConnector``, ``SamRestApiConnector``,
-    ``SysML2ProjectManager``, and ``SAMDiagramManager``.
+    The :class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` class is specifically designed for SAM projects and automatically handles the initialization of these classes: :class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`, :class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>`,
+    :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>`, and :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>`.
 
 Prerequisites for simplified SAM
 ================================
@@ -39,15 +39,15 @@ Key advantages
 ==============
 
 Compared to the traditional approach described in :ref:`Download diagrams and create new elements<Download_Example>`, using the simplified
-:class:`ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project` class offers these advantages:
+:class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` class offers these advantages:
 
 - **Single initialization**: One class automatically handles all connectors.
-- **Built-in diagram management**: Removes the need to manually create and manage the ``SAMDiagramManager`` class.
+- **Built-in diagram management**: Removes the need to manually create and manage the :class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>` class.
 - **Streamlined API**: Provides direct access to project operations without managing multiple connector instances.
 - **Integrated features**: Combines project management, diagram operations, and element creation in one interface.
 
 .. note::
 
   - Replace placeholder values with your actual SAM configuration.
-  - The ``AnsysSysML2Project`` class automatically manages diagram loading and the connector lifecycle.
+  - The :class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` class automatically manages diagram loading and the connector lifecycle.
   - The class supports all diagram formats (``png``, ``svg``, ``jpeg``) for downloads.

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -15,7 +15,7 @@ Install PySAM SysML2
 Connect to the tool
 -------------------
 
-The following code connects to PySAM SysML2 using the AnsysSysML2 API connector.
+The following code connects to PySAM SysML2 using the :class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`.
 
 .. literalinclude:: ../_static/code/weight-bike.py
     :lines: 7

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -1,7 +1,8 @@
 Getting started
 ===============
 
-This section explains how to install PySAM SysML2 and set up a project, including loading and initializing it.
+This section explains how to install PySAM SysML2 and set up a project, including loading and
+initializing it.
 
 .. _Installation_Section:
 
@@ -15,7 +16,8 @@ Install PySAM SysML2
 Connect to the tool
 -------------------
 
-The following code connects to PySAM SysML2 using the :class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`.
+The following code connects to PySAM SysML2 using the
+:class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`.
 
 .. literalinclude:: ../_static/code/weight-bike.py
     :lines: 7

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,9 +1,12 @@
 PySAM SysML2
 #############
 
-PySAM SysML2 provides a Python scripting interface for SysML2 models. It loads models from any SysML2 tool that implements the standard API. The loaded model maps into a Python object, allowing you to manipulate, browse, and edit it. You can then push modifications back to your modeling tool.
+PySAM SysML2 provides a Python scripting interface for SysML2 models. It loads models from any
+SysML2 tool that implements the standard API. The loaded model maps into a Python object, allowing
+you to manipulate, browse, and edit it. You can then push modifications back to your modeling tool.
 
-PySAM SysML2 works with the Ansys SysML2 modeling tool, `Ansys System Architecture Modeler (SAM) <https://www.ansys.com/products/connect/ansys-system-architecture-modeler>`_.
+PySAM SysML2 works with the Ansys SysML2 modeling tool,
+`Ansys System Architecture Modeler (SAM) <https://www.ansys.com/products/connect/ansys-system-architecture-modeler>`_.
 
 .. only:: html
 
@@ -19,7 +22,8 @@ PySAM SysML2 works with the Ansys SysML2 modeling tool, `Ansys System Architectu
             :link: user_guide/index
             :link-type: doc
 
-            Explains how to connect to PySAM SysML2, work with models and diagrams, and find required information.
+            Explains how to connect to PySAM SysML2, work with models and diagrams, and find
+            required information.
 
         .. grid-item-card:: API reference :fa:`file-lines`
             :link: api/index

--- a/doc/source/user_guide/api/create-conn.rst
+++ b/doc/source/user_guide/api/create-conn.rst
@@ -10,8 +10,8 @@ A connector is the interface between PySAM SysML2 and the SysML V2 server.
     To find all required data, such as organization IDs and tokens, see
     :ref:`Find information <Info_Section>`.
 
-:class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`
-----------------------------------------------------------------------------------------------------------
+Ansys SysML2 API Connector
+--------------------------
 
 PySAM SysML2 uses the standard API to load and publish information in a model.
 
@@ -20,10 +20,10 @@ PySAM SysML2 uses the standard API to load and publish information in a model.
     :language: python
     :caption: Connect to the SysML2 API server
 
-:class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>`
--------------------------------------------------------------------------------------------------------
+SAM REST API Connector
+----------------------
 
-PySAM SysML2 uses the SAM REST API to retrieve diagrams in the model.
+PySAM SysML2 uses the :class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>` to retrieve diagrams in the model.
 
 .. literalinclude:: ../../_static/code/download-diagrams.py
     :lines: 21-25

--- a/doc/source/user_guide/api/create-conn.rst
+++ b/doc/source/user_guide/api/create-conn.rst
@@ -7,7 +7,8 @@ A connector is the interface between PySAM SysML2 and the SysML V2 server.
 
 .. note::
 
-    To find all required data, such as organization IDs and tokens, see :ref:`Find information <Info_Section>`.
+    To find all required data, such as organization IDs and tokens, see
+    :ref:`Find information <Info_Section>`.
 
 :class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`
 ----------------------------------------------------------------------------------------------------------

--- a/doc/source/user_guide/api/create-conn.rst
+++ b/doc/source/user_guide/api/create-conn.rst
@@ -9,8 +9,8 @@ A connector is the interface between PySAM SysML2 and the SysML V2 server.
 
     To find all required data, such as organization IDs and tokens, see :ref:`Find information <Info_Section>`.
 
-Ansys SysML2 API Connector
---------------------------
+:class:`AnsysSysML2APIConnector <ansys.sam.sysml2.api.ansys_sysml2_api_connector.AnsysSysML2APIConnector>`
+----------------------------------------------------------------------------------------------------------
 
 PySAM SysML2 uses the standard API to load and publish information in a model.
 
@@ -19,8 +19,8 @@ PySAM SysML2 uses the standard API to load and publish information in a model.
     :language: python
     :caption: Connect to the SysML2 API server
 
-SAM REST API Connector
-----------------------
+:class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>`
+-------------------------------------------------------------------------------------------------------
 
 PySAM SysML2 uses the SAM REST API to retrieve diagrams in the model.
 

--- a/doc/source/user_guide/api/diagram-model.rst
+++ b/doc/source/user_guide/api/diagram-model.rst
@@ -11,9 +11,9 @@ Load diagrams
 =============
 
 Before interacting with diagrams, load them using the
-:class:`ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader` context manager, which requires an :mod:`ansys.sam.sysml2.api` connector.
+:class:`SamDiagramDownloader <ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader>` context manager, which requires an :mod:`API <ansys.sam.sysml2.api>` connector.
 
-Create a SAM REST API connector:
+Create a :class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>` :
 
 .. literalinclude:: ../../_static/code/download-diagrams.py
     :lines: 21-25
@@ -27,16 +27,16 @@ Load diagrams from a project and make them available for further operations like
     :language: python
     :caption: Load diagrams using SAM diagram manager
 
-Outside the ``with`` block, the ``SamDiagramDownloader`` context manager is no longer active. This ensures proper setup and cleanup of resources when working with diagrams.
+Outside the ``with`` block, the :class:`SamDiagramDownloader <ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader>` context manager is no longer active. This ensures proper setup and cleanup of resources when working with diagrams.
 
 Download diagrams
 =================
 
 Load diagrams inside an
-:class:`ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager` context before downloading them.
+:class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>` context before downloading them.
 
 Also, instantiate an
-:class:`ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader` object:
+:class:`SamDiagramDownloader <ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader>` object:
 
 .. literalinclude:: ../../_static/code/download-diagrams.py
     :lines: 40

--- a/doc/source/user_guide/api/diagram-model.rst
+++ b/doc/source/user_guide/api/diagram-model.rst
@@ -3,17 +3,21 @@ Work with diagrams
 
 .. warning::
 
-    Functionalities for loading, downloading, and navigating diagrams are available only for projects of type ``SAM``.
+    Functionalities for loading, downloading, and navigating diagrams are available only for
+    projects of type ``SAM``.
 
-This page explains how to load, download, and navigate diagrams from your SysML v2 project using the SAM REST API.
+This page explains how to load, download, and navigate diagrams from your SysML v2 project using
+the SAM REST API.
 
 Load diagrams
 =============
 
 Before interacting with diagrams, load them using the
-:class:`SamDiagramDownloader <ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader>` context manager, which requires an :mod:`API <ansys.sam.sysml2.api>` connector.
+:class:`SamDiagramDownloader <ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader>`
+context manager, which requires an :mod:`API <ansys.sam.sysml2.api>` connector.
 
-Create a :class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>` :
+Create a
+:class:`SamRestApiConnector <ansys.sam.sysml2.diagrams.api.sam_rest_api_connector.SamRestApiConnector>`:
 
 .. literalinclude:: ../../_static/code/download-diagrams.py
     :lines: 21-25
@@ -27,16 +31,21 @@ Load diagrams from a project and make them available for further operations like
     :language: python
     :caption: Load diagrams using SAM diagram manager
 
-Outside the ``with`` block, the :class:`SamDiagramDownloader <ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader>` context manager is no longer active. This ensures proper setup and cleanup of resources when working with diagrams.
+Outside the ``with`` block, the
+:class:`SamDiagramDownloader <ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader>`
+context manager is no longer active. This ensures proper setup and cleanup of resources when
+working with diagrams.
 
 Download diagrams
 =================
 
 Load diagrams inside an
-:class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>` context before downloading them.
+:class:`SAMDiagramManager <ansys.sam.sysml2.diagrams.sam_diagram_manager.SAMDiagramManager>`
+context before downloading them.
 
 Also, instantiate an
-:class:`SamDiagramDownloader <ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader>` object:
+:class:`SamDiagramDownloader <ansys.sam.sysml2.diagrams.tools.sam_diagram_downloader.SamDiagramDownloader>`
+object:
 
 .. literalinclude:: ../../_static/code/download-diagrams.py
     :lines: 40
@@ -108,7 +117,8 @@ Get diagram metadata
     :language: python
     :caption: Get diagram metadata from the model element
 
-Getting the diagram metadata returns the name of the associated model element that the diagram represents.
+Getting the diagram metadata returns the name of the associated model element that the diagram
+represents.
 
 Loop through diagrams
 ---------------------

--- a/doc/source/user_guide/api/information.rst
+++ b/doc/source/user_guide/api/information.rst
@@ -3,7 +3,8 @@
 Find information
 ################
 
-This page explains how to find required information, such as the project ID or your authorization token.
+This page explains how to find required information, such as the project ID or your authorization
+token.
 
 .. _Info_P_Id_Section:
 
@@ -43,7 +44,8 @@ Follow these steps to find your organization ID:
 Find authorization token
 ========================
 
-For authorization, you can either use a bearer (temporary) token for quick access or create a Personal Access Token (PAT) for longer-term use.
+For authorization, you can either use a bearer (temporary) token for quick access or create a
+Personal Access Token (PAT) for longer-term use.
 
 Bearer token
 ~~~~~~~~~~~~
@@ -71,7 +73,8 @@ The **Authorization** header shows the value of your bearer token.
 Personal Access Token (PAT)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Creating a Personal Access Token (PAT) is the recommended method for authentication with PySAM due to its longer validity.
+Creating a Personal Access Token (PAT) is the recommended method for authentication with
+PySAM SysML2 due to its longer validity.
 
 **New method (recommended for current servers)**
 

--- a/doc/source/user_guide/api/load-model.rst
+++ b/doc/source/user_guide/api/load-model.rst
@@ -3,13 +3,13 @@ Load a model
 
 To load a model, you need an instance of a SysML Connector. For more information, (see :ref:`Use a connector <Create_C_Section>`).
 
-You can then create a :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>`.
-This class helps you load a model in Python, using the SysML V2 Standard API.
+You can then create an instance of the :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>` class.
+This class helps you load a model in Python, using the SysML V2 standard API.
 
 .. literalinclude:: ../../_static/code/computer-cost.py
     :lines: 19
     :language: python
-    :caption: Create SysML2 project manager
+    :caption: Create a SysML2 project manager instance
 
 For more information, see the :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>` class.
 

--- a/doc/source/user_guide/api/load-model.rst
+++ b/doc/source/user_guide/api/load-model.rst
@@ -3,7 +3,7 @@ Load a model
 
 To load a model, you need an instance of a SysML Connector. For more information, (see :ref:`Use a connector <Create_C_Section>`).
 
-You can then create a SysML2 project manager.
+You can then create a :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>`.
 This class helps you load a model in Python, using the SysML V2 Standard API.
 
 .. literalinclude:: ../../_static/code/computer-cost.py
@@ -11,7 +11,7 @@ This class helps you load a model in Python, using the SysML V2 Standard API.
     :language: python
     :caption: Create SysML2 project manager
 
-For more information, see the :class:`ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager` class.
+For more information, see the :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>` class.
 
 With the project manager, you can load your project like this:
 

--- a/doc/source/user_guide/api/read-model.rst
+++ b/doc/source/user_guide/api/read-model.rst
@@ -3,7 +3,7 @@ Read your model
 
 PySAM SysML2 lets you read and parse the model through a Python script.
 
-The loaded model is stored in a :class:`ansys.sam.sysml2.classes.project.Project` object.
+The loaded model is stored in a :class:`Project <ansys.sam.sysml2.classes.project.Project>` object.
 
 .. _Getter:
 
@@ -15,7 +15,9 @@ To parse the project, you can use dot access or underscore access.
 Dot access
 ----------
 
-With dot access, you can access all direct named elements of your SysML element. Also, you can access some useful top-level functions, such as ``get_value()``.
+.. currentmodule:: ansys.sam.sysml2.classes.sysml_element
+
+With dot access, you can access all direct named elements of your SysML element. Also, you can access some useful top-level functions, such as :meth:`get_value() <SysMLElement.get_value>`.
 
 Sub-elements
 ~~~~~~~~~~~~
@@ -33,10 +35,10 @@ The following code attaches all elements contained in ``ownedElement`` and ``_in
 
 - **Names with spaces**: You cannot access elements with spaces in their names (for example, "bike frame") using dot notation. Python identifiers cannot contain spaces.
 
-Function ``get_value()``
+Function :meth:`get_value() <SysMLElement.get_value>`
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``get_value()`` function works only for the SysML ``Feature`` element. Use this top-level function to get the value of the feature without reading the internal structure:
+The :meth:`get_value() <SysMLElement.get_value>` function works only for the SysML ``Feature`` element. Use this top-level function to get the value of the feature without reading the internal structure:
 
 .. code:: bash
 
@@ -51,7 +53,7 @@ The ``get_value()`` function works only for the SysML ``Feature`` element. Use t
     >>> myFloatFeature.get_value()
     10.56
 
-The ``get_value`` function supports:
+The :meth:`get_value() <SysMLElement.get_value>` function supports:
 
 - All primitive types, such as LiteralInteger and LiteralString. - Returns the value directly.
 - Simple expressions, such as ``<value> [<unit>]`` - Returns a tuple: ``(<value>,<unit short name>)``.

--- a/doc/source/user_guide/api/read-model.rst
+++ b/doc/source/user_guide/api/read-model.rst
@@ -17,12 +17,14 @@ Dot access
 
 .. currentmodule:: ansys.sam.sysml2.classes.sysml_element
 
-With dot access, you can access all direct named elements of your SysML element. Also, you can access some useful top-level functions, such as :meth:`get_value() <SysMLElement.get_value>`.
+With dot access, you can access all direct named elements of your SysML element. Also, you can
+access some useful top-level functions, such as :meth:`get_value() <SysMLElement.get_value>`.
 
 Sub-elements
 ~~~~~~~~~~~~
 
-The following code attaches all elements contained in ``ownedElement`` and ``_inheritedFeature``, which have names, to the container element.
+The following code attaches all elements contained in ``ownedElement`` and ``_inheritedFeature``,
+which have names, to the container element.
 
 .. code:: python
 
@@ -31,14 +33,18 @@ The following code attaches all elements contained in ``ownedElement`` and ``_in
 
 **Limitations of dot access for sub-elements:**
 
-- **Duplicate names**: If multiple elements have the same name, only one is accessible through dot access. You cannot differentiate between elements with identical names using this method.
+- **Duplicate names**: If multiple elements have the same name, only one is accessible through dot
+  access. You cannot differentiate between elements with identical names using this method.
 
-- **Names with spaces**: You cannot access elements with spaces in their names (for example, "bike frame") using dot notation. Python identifiers cannot contain spaces.
+- **Names with spaces**: You cannot access elements with spaces in their names (for example, "bike
+  frame") using dot notation. Python identifiers cannot contain spaces.
 
 Function :meth:`get_value() <SysMLElement.get_value>`
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :meth:`get_value() <SysMLElement.get_value>` function works only for the SysML ``Feature`` element. Use this top-level function to get the value of the feature without reading the internal structure:
+The :meth:`get_value() <SysMLElement.get_value>` function works only for the SysML ``Feature``
+element. Use this top-level function to get the value of the feature without reading the internal
+structure:
 
 .. code:: bash
 
@@ -55,8 +61,9 @@ The :meth:`get_value() <SysMLElement.get_value>` function works only for the Sys
 
 The :meth:`get_value() <SysMLElement.get_value>` function supports:
 
-- All primitive types, such as LiteralInteger and LiteralString. - Returns the value directly.
-- Simple expressions, such as ``<value> [<unit>]`` - Returns a tuple: ``(<value>,<unit short name>)``.
+- All primitive types, such as LiteralInteger and LiteralString - Returns the value directly.
+- Simple expressions, such as ``<value> [<unit>]`` - Returns a tuple:
+  ``(<value>,<unit short name>)``.
 
 Underscore access
 =================
@@ -72,7 +79,8 @@ With underscore (``_``) access, you can find all SysML methods:
 
 .. note::
 
-    In this first PySAM SysML2 version, only existing fields (with data) are linked, which means that you might not find a function that exists in SysML V2.
+    In this first PySAM SysML2 version, only existing fields (with data) are linked, which means
+    that you might not find a function that exists in SysML V2.
 
 .. only:: html
 

--- a/doc/source/user_guide/api/write-model.rst
+++ b/doc/source/user_guide/api/write-model.rst
@@ -40,7 +40,8 @@ The model updates after you set all values to ensure accuracy.
 Function :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>`
 --------------------------------------------------------------------------
 
-The :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>` function handles more complex expressions:
+The :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>` function handles more complex
+expressions:
 
 .. code:: python
 
@@ -67,7 +68,8 @@ Use the :class:`Factory` class to create new elements in your model.
     :language: python
     :caption: Create a Factory instance
 
-Use the :meth:`create_element() <Factory.create_element>` method to create a new model element. Provide the element type and any number of keyword arguments representing its attributes:
+Use the :meth:`create_element() <Factory.create_element>` method to create a new model element.
+Provide the element type and any number of keyword arguments representing its attributes:
 
 .. code:: python
 
@@ -76,18 +78,21 @@ Use the :meth:`create_element() <Factory.create_element>` method to create a new
         name="new_attribute_usage",
     )
 
-This creates a new ``AttributeUsage`` element at the root of your project. The :meth:`create_element() <Factory.create_element>` method returns the newly created element.
+This creates a new ``AttributeUsage`` element at the root of your project. The
+:meth:`create_element() <Factory.create_element>` method returns the newly created element.
 
 .. literalinclude:: ../../_static/code/creating-elements.py
     :lines: 27-29
     :language: python
     :caption: Create a new AttributeUsage element with owner
 
-This creates a new ``AttributeUsage`` element with the specified attributes inside the ``Bike`` frame.
+This creates a new ``AttributeUsage`` element with the specified attributes inside the ``Bike``
+frame.
 
 .. note::
 
-    The list of accepted attributes depends on the element type you are creating. For example, ``name``, ``owner``, ``shortName``, and others are defined by the ``metamodel``.
+    The list of accepted attributes depends on the element type you are creating. For example,
+    ``name``, ``owner``, ``shortName``, and others are defined by the ``metamodel``.
 
     You can also assign a value directly when creating the element. There are two ways:
 
@@ -115,7 +120,8 @@ This creates a new ``AttributeUsage`` element with the specified attributes insi
 Update attributes directly
 --------------------------
 
-Update element properties directly using simple assignment. This is useful for quickly changing properties like names.
+Update element properties directly using simple assignment. This is useful for quickly changing
+properties like names.
 
 .. code:: python
 

--- a/doc/source/user_guide/api/write-model.rst
+++ b/doc/source/user_guide/api/write-model.rst
@@ -10,13 +10,15 @@ Update a feature value
 
 You have two functions for updating the value of a feature:
 
-- ``set_value()``
-- ``parse_and_set_value()``
+.. currentmodule:: ansys.sam.sysml2.classes.sysml_element
 
-Function ``set_value()``
-------------------------
+- :meth:`set_value() <SysMLElement.set_value>`
+- :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>`
 
-The ``set_value()`` function supports all primitive types:
+Function :meth:`set_value() <SysMLElement.set_value>`
+------------------------------------------------------
+
+The :meth:`set_value() <SysMLElement.set_value>` function supports all primitive types:
 
 .. code:: python
 
@@ -35,10 +37,10 @@ The ``set_value()`` function supports all primitive types:
 
 The model updates after you set all values to ensure accuracy.
 
-Function ``parse_and_set_value()``
-----------------------------------
+Function :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>`
+--------------------------------------------------------------------------
 
-The ``parse_and_set_value`` function handles more complex expressions:
+The :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>` function handles more complex expressions:
 
 .. code:: python
 
@@ -52,7 +54,9 @@ The ``parse_and_set_value`` function handles more complex expressions:
 Create new elements
 ===================
 
-Use the ``Factory`` class to create new elements in your model.
+.. currentmodule:: ansys.sam.sysml2.tools.factory
+
+Use the :class:`Factory` class to create new elements in your model.
 
 .. tip::
 
@@ -63,7 +67,7 @@ Use the ``Factory`` class to create new elements in your model.
     :language: python
     :caption: Create a Factory instance
 
-Use the ``create_element()`` method to create a new model element. Provide the element type and any number of keyword arguments representing its attributes:
+Use the :meth:`create_element() <Factory.create_element>` method to create a new model element. Provide the element type and any number of keyword arguments representing its attributes:
 
 .. code:: python
 
@@ -72,7 +76,7 @@ Use the ``create_element()`` method to create a new model element. Provide the e
         name="new_attribute_usage",
     )
 
-This creates a new ``AttributeUsage`` element at the root of your project. The ``create_element()`` method returns the newly created element.
+This creates a new ``AttributeUsage`` element at the root of your project. The :meth:`create_element() <Factory.create_element>` method returns the newly created element.
 
 .. literalinclude:: ../../_static/code/creating-elements.py
     :lines: 27-29

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -1,7 +1,8 @@
 User guide
 ----------
 
-This section explains how to connect to PySAM SysML2, work with models and diagrams, and find required information.
+This section explains how to connect to PySAM SysML2, work with models and diagrams, and find
+required information.
 
 .. only:: html
 
@@ -11,7 +12,8 @@ This section explains how to connect to PySAM SysML2, work with models and diagr
             :link: api/create-conn
             :link-type: doc
 
-            Explains how to use a connector, which is the interface between PySAM SysML2 and the SysML V2 server.
+            Explains how to use a connector, which is the interface between PySAM SysML2 and the
+            SysML V2 server.
 
         .. grid-item-card:: Load a model :fa:`cloud-download`
             :link: api/load-model

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -1,38 +1,35 @@
 ANSYS
 [Aa]nsys
-isort
-Makefile
-py
-pytest
-Python
-get_value
-parse_and_set_value
-myExpressionFeature
-myIntFeature
-myStringFeature
-myBoolFeature
-myFloatFeature
-PySam
 AnsysSysML2APIConnector
-SysML2APIConnector
+AnsysSysML2APIConnector
+API
 DiagramDownloader
 DiagramElement
-SysML2DiagramManager
 Factory
+get_value
+isort
+Makefile
+myBoolFeature
+myExpressionFeature
+myFloatFeature
+myIntFeature
+myStringFeature
+Oops!
+parse_and_set_value
+PAT
+Personal Access Token
+py
+PySAM
+pytest
+Python
+SAM
+SAMDiagramManager
+SamRestApiConnector
+SamRestApiConnector
+SysML2
+SysML2APIConnector
+SysML2DiagramManager
 SysML2ProjectManager
 SysMLElement
 SysMLTools
-PAT
-Personal Access Token
-SAM
 theme_contact_mail
-AnsysSysML2APIConnector
-SamRestApiConnector
-SAMDiagramManager
-API
-SamRestApiConnector
-Oops!
-SysML2
-Ansys SysML2 API Connector
-SAM Rest API Connector
-PySAM SysML2

--- a/examples/code/simplified-sam-project.py
+++ b/examples/code/simplified-sam-project.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""AnsysSysML2Project Example for PySam."""
+"""AnsysSysML2Project Example for PySAM SysML2."""
 
 import requests
 from urllib3.exceptions import InsecureRequestWarning

--- a/examples/code/simplified-sam-project.py
+++ b/examples/code/simplified-sam-project.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""AnsysSysML2Project Example for PySAM SysML2."""
+"""Ansys SysML2 project example for PySAM SysML2."""
 
 import requests
 from urllib3.exceptions import InsecureRequestWarning

--- a/examples/code/weight-bike.py
+++ b/examples/code/weight-bike.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Weight Bike Example for PySAM SysML2."""
+"""Weight bike example for PySAM SysML2."""
 
 # Import connector and model manager
 import requests

--- a/examples/code/weight-bike.py
+++ b/examples/code/weight-bike.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Weight Bike Example for PySam."""
+"""Weight Bike Example for PySAM SysML2."""
 
 # Import connector and model manager
 import requests

--- a/tests/mocked_server/json/project_1/elements.json
+++ b/tests/mocked_server/json/project_1/elements.json
@@ -4,7 +4,7 @@
         "@id": "201e3e4e-d36c-4848-87b0-8b4a69ed6ef4",
         "identifier": "201e3e4e-d36c-4848-87b0-8b4a69ed6ef4",
         "eAnnotations": [],
-        "name": "PySamTestProject-COMPLET",
+        "name": "PySAMSysML2TestProject-COMPLET",
         "ownedElement": [
             {
                 "@id": "6afc9e87-1079-4212-8fa4-99cd6b2004fc"
@@ -13,7 +13,7 @@
                 "@id": "fd36d11a-bc48-410e-bec9-b7f929666c4c"
             }
         ],
-        "qualifiedName": "PySamTestProject-COMPLET",
+        "qualifiedName": "PySAMSysML2TestProject-COMPLET",
         "ownedMember": [
             {
                 "@id": "6afc9e87-1079-4212-8fa4-99cd6b2004fc"
@@ -33,7 +33,7 @@
                 "@id": "ecf75010-3603-4e1e-82d5-db312b093378"
             }
         ],
-        "qualifiedName": "PySamTestProject-COMPLET::PartDefinition",
+        "qualifiedName": "PySAMSysML2TestProject-COMPLET::PartDefinition",
         "owner": {
             "@id": "201e3e4e-d36c-4848-87b0-8b4a69ed6ef4"
         },
@@ -73,7 +73,7 @@
         "@id": "ecf75010-3603-4e1e-82d5-db312b093378",
         "identifier": "ecf75010-3603-4e1e-82d5-db312b093378",
         "name": "Attribute",
-        "qualifiedName": "PySamTestProject-COMPLET::PartDefinition::Attribute",
+        "qualifiedName": "PySAMSysML2TestProject-COMPLET::PartDefinition::Attribute",
         "owner": {
             "@id": "6afc9e87-1079-4212-8fa4-99cd6b2004fc"
         },
@@ -90,7 +90,7 @@
         "@id": "fd36d11a-bc48-410e-bec9-b7f929666c4c",
         "identifier": "fd36d11a-bc48-410e-bec9-b7f929666c4c",
         "name": "myPartUsage",
-        "qualifiedName": "PySamTestProject-COMPLET::myPartUsage",
+        "qualifiedName": "PySAMSysML2TestProject-COMPLET::myPartUsage",
         "owner": {
             "@id": "201e3e4e-d36c-4848-87b0-8b4a69ed6ef4"
         },

--- a/tests/mocked_server/json/project_1/project.json
+++ b/tests/mocked_server/json/project_1/project.json
@@ -4,6 +4,6 @@
         "@id": "defaultBranch"
     },
     "description": "",
-    "name": "PySamTestProject-COMPLET",
+    "name": "PySAMSysML2TestProject-COMPLET",
     "@id": "1"
 }

--- a/tests/sam/sysml2/api/test_sysml2_api_connector_endpoint.py
+++ b/tests/sam/sysml2/api/test_sysml2_api_connector_endpoint.py
@@ -204,7 +204,7 @@ class TestSysML2APIConnectorEndpoint(ParentTestClass):
 
         bike = project.get_root_package()
 
-        assert bike._name == "PySamTestProject-COMPLET"
+        assert bike._name == "PySAMSysML2TestProject-COMPLET"
 
         bike._name = "TEST"
 

--- a/tests/sam/sysml2/builder/test_sysml2_project_builder.py
+++ b/tests/sam/sysml2/builder/test_sysml2_project_builder.py
@@ -33,8 +33,8 @@ class TestSysML2ProjectBuilder(ParentTestClass):
         builder = SysML2ProjectBuilder(valid_source)
         project = builder.build_project(PROJECT_ID_1)
         assert len(project.get_root()) == 1
-        assert project.get_root()[0]._name == "PySamTestProject-COMPLET"
-        assert project.get_root_package()._name == "PySamTestProject-COMPLET"
+        assert project.get_root()[0]._name == "PySAMSysML2TestProject-COMPLET"
+        assert project.get_root_package()._name == "PySAMSysML2TestProject-COMPLET"
 
     def test_find_element_by_id(self, valid_source: AnsysSysML2APIConnector):
         builder = SysML2ProjectBuilder(valid_source)

--- a/tests/sam/sysml2/builder/test_sysml2_project_manager.py
+++ b/tests/sam/sysml2/builder/test_sysml2_project_manager.py
@@ -31,4 +31,4 @@ class TestSysML2ProjectManager(ParentTestClass):
         manager = SysML2ProjectManager(valid_source)
         project = manager.get_project("1")
         assert len(project.get_root()) == 1
-        assert project.get_root()[0]._name == "PySamTestProject-COMPLET"
+        assert project.get_root()[0]._name == "PySAMSysML2TestProject-COMPLET"


### PR DESCRIPTION
Change class and method references to improve readability in the documentation. All class and method references are now clickable links that navigate to their corresponding API documentation pages.

@clatapie