### PR TITLE
docs: complete and standardize NumPy-style docstrings

### DIFF
--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -1,10 +1,13 @@
-ANSYS
 [Aa]nsys
+ANSYS
+Ansys SysML2 API Connector
 AnsysSysML2APIConnector
 AnsysSysML2APIConnector
 API
 DiagramDownloader
 DiagramElement
+downloader
+Enum
 Factory
 get_value
 isort
@@ -23,6 +26,7 @@ PySAM
 pytest
 Python
 SAM
+SAM REST API Connector
 SAMDiagramManager
 SamRestApiConnector
 SamRestApiConnector

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ doc = [
     "sphinx==8.1.3",
     "sphinx-copybutton==0.5.2",
 ]
-tests=[
+tests = [
     "pytest==8.4.1",
     "pytest-cov==6.2.1",
     "requests==2.32.4",
@@ -56,7 +56,7 @@ tests=[
     "sphinx-copybutton==0.5.2",
     "sphinx-design==0.6.1",
     "urllib3==2.5.0",
-    "vale==3.12.0.0",
+    "vale==3.12.0",
     "Werkzeug==3.1.3",
 ]
 checks = [
@@ -69,7 +69,7 @@ checks = [
     "MarkupSafe==3.0.2",
     "numpydoc==1.8.0",
     "ruff==0.8.2",
-    "vale==3.9.1",
+    "vale==3.12.0",
     "pre-commit==4.2.0",
 ]
 

--- a/src/ansys/sam/sysml2/api/ansys_sysml2_api_connector.py
+++ b/src/ansys/sam/sysml2/api/ansys_sysml2_api_connector.py
@@ -22,7 +22,9 @@
 
 """Module for Ansy SysML2 API connector."""
 
-from ansys.sam.sysml2.api.template_sysml2_api_connector import TemplateSysML2APIConnector
+from ansys.sam.sysml2.api.template_sysml2_api_connector import (
+    TemplateSysML2APIConnector,
+)
 from ansys.sam.sysml2.classes.http_request import HttpRequest
 
 
@@ -62,19 +64,7 @@ class AnsysSysML2APIConnector(TemplateSysML2APIConnector):
         self._token = token
 
     def _build_endpoint(self, endpoint: str) -> str:
-        """
-        Build the full URL from the API endpoint.
-
-        Parameters
-        ----------
-        endpoint : str
-            API endpoint.
-
-        Returns
-        -------
-        str
-            Full API URL.
-        """
+        """Build the full URL from the API endpoint."""
         if not endpoint.startswith("/"):
             endpoint = "/" + endpoint
         return f"{self._server_url}/api/spaces/{self._organization_id}/sysml2{endpoint}"

--- a/src/ansys/sam/sysml2/api/sysml2_api_connector.py
+++ b/src/ansys/sam/sysml2/api/sysml2_api_connector.py
@@ -44,8 +44,8 @@ class SysML2APIConnector:
         ----------
         project_name : str
             Name of the project.
-        project_description : str
-            Description of the project, by default : "Project description".
+        project_description : str, default: ``"Project description"``
+            Description of the project.
 
         Returns
         -------

--- a/src/ansys/sam/sysml2/api/sysml2_api_connector.py
+++ b/src/ansys/sam/sysml2/api/sysml2_api_connector.py
@@ -24,7 +24,7 @@
 
 
 class SysML2APIConnector:
-    """Provides the ysML2 API Connector interface."""
+    """Provides the SysML2 API Connector interface."""
 
     def get_projects(self) -> list:
         """Get all projects of the connected user."""
@@ -37,7 +37,21 @@ class SysML2APIConnector:
         project_name: str,
         project_description: str = "Project description",
     ) -> dict:
-        """Create a project with the associated name and description."""
+        """
+        Create a project with the associated name and description.
+
+        Parameters
+        ----------
+        project_name : str
+            Name of the project.
+        project_description : str
+            Description of the project, by default : "Project description".
+
+        Returns
+        -------
+        dict
+            Project record.
+        """
 
     def get_all_elements(self, project_id: str) -> list:
         """Get all elements of the given project."""

--- a/src/ansys/sam/sysml2/api/template_sysml2_api_connector.py
+++ b/src/ansys/sam/sysml2/api/template_sysml2_api_connector.py
@@ -339,19 +339,7 @@ class TemplateSysML2APIConnector(SysML2APIConnector):
             raise HTTPResponseException(response.content)
 
     def _build_endpoint(self, endpoint: str) -> str:
-        """
-        Build the full URL from the API endpoint.
-
-        Parameters
-        ----------
-        endpoint : str
-            API endpoint.
-
-        Returns
-        -------
-        str
-            Full API URL.
-        """
+        """Build the full URL from the API endpoint."""
 
     def _add_authentication_field(self, http_request: HttpRequest) -> HttpRequest:
         """

--- a/src/ansys/sam/sysml2/builder/classes/project_impl.py
+++ b/src/ansys/sam/sysml2/builder/classes/project_impl.py
@@ -48,6 +48,8 @@ class ProjectImpl(Project):
         ----------
         id : str
             Project ID.
+        name : str
+            Project Name.
         """
         super().__init__()
         self._id = id
@@ -58,14 +60,7 @@ class ProjectImpl(Project):
         self._env = dict()
 
     def add_element(self, element: SysMLElement):
-        """
-        Add an element to the project environment.
-
-        Parameters
-        ----------
-        element : SysMLElement
-            Element to add.
-        """
+        """Add an element to the project environment."""
         self._env[element._id] = element
 
     def update_unresolved_fields(self, unresolved_fields: List[UnresolvedField]):
@@ -95,14 +90,7 @@ class ProjectImpl(Project):
         return [x for x in self._root if x.__class__.__name__ == "Package"][0]
 
     def get_name(self) -> str:
-        """
-        Get the project name.
-
-        Returns
-        -------
-        str
-            Project name.
-        """
+        """Get the project name."""
         return self._name
 
     def find_element_by_id(self, element_id: str) -> SysMLElement:

--- a/src/ansys/sam/sysml2/builder/classes/project_impl.py
+++ b/src/ansys/sam/sysml2/builder/classes/project_impl.py
@@ -49,7 +49,7 @@ class ProjectImpl(Project):
         id : str
             Project ID.
         name : str
-            Project Name.
+            Project name.
         """
         super().__init__()
         self._id = id

--- a/src/ansys/sam/sysml2/builder/classes/sysml_util.py
+++ b/src/ansys/sam/sysml2/builder/classes/sysml_util.py
@@ -29,19 +29,7 @@ class SysMLUtil:
 
     @staticmethod
     def check_inherited_name(element: SysMLElement) -> str:
-        """
-        Check and return the name.
-
-        Parameters
-        ----------
-        element : SysMLElement
-            Element.
-
-        Returns
-        -------
-        str
-           Name.
-        """
+        """Check and return the name of the element."""
         if isinstance(element, str):
             return "::" + element
         if hasattr(element, "_name"):

--- a/src/ansys/sam/sysml2/builder/json_mapper.py
+++ b/src/ansys/sam/sysml2/builder/json_mapper.py
@@ -54,6 +54,8 @@ class JsonMapper:
             Element data.
         name_space: str
             Project name space.
+        mapped_element: SysMLElement
+            SysMLElement.
 
         Returns
         -------
@@ -75,6 +77,8 @@ class JsonMapper:
             Element data.
         name_space: str
             Project name space.
+        element: SysMLElement
+            SysMLElement.
 
         Returns
         -------
@@ -153,7 +157,7 @@ class JsonMapper:
             Destination element.
         field_name : str
             Field name.
-        field_value : Union[dict  |  list  |  str]
+        field_value : str
             Field value.
 
         Returns
@@ -164,7 +168,9 @@ class JsonMapper:
         setattr(element, field_name, field_value)
         return []
 
-    def __add_element_to_field(self, element: SysMLElement, key: str, value: dict):
+    def __add_element_to_field(
+        self, element: SysMLElement, key: str, value: dict
+    ) -> List[UnresolvedField]:
         """
         Adder function for simple element field.
 
@@ -174,7 +180,7 @@ class JsonMapper:
             Destination element.
         key : str
             Field name.
-        value : Union[dict  |  list  |  str]
+        value : dict
             Field value.
 
         Returns
@@ -185,7 +191,9 @@ class JsonMapper:
         setattr(element, key, value["@id"])
         return [UnresolvedField(element, key, value["@id"])]
 
-    def __add_list_to_field(self, element: SysMLElement, key: str, field_values: list):
+    def __add_list_to_field(
+        self, element: SysMLElement, key: str, field_values: list
+    ) -> List[UnresolvedField]:
         """
         Adder function for list elements value.
 
@@ -195,7 +203,7 @@ class JsonMapper:
             Destination element.
         key : str
             Field name.
-        field_values : Union[dict  |  list  |  str]
+        field_values : list
             Field values.
 
         Returns

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -46,11 +46,11 @@ class SysML2ProjectBuilder:
     _mapper: JsonMapper = JsonMapper()
 
     def __init__(self, connector: SysML2APIConnector):
-        """Construct a new instance with a specified SysML2APIConnector."""
+        """Construct a new instance with a specified SysML2 API Connector."""
         self._connector = connector
 
     def build_project(self, project_id: str) -> Project:
-        """Call the API with the specified project id and build the Project from JSON."""
+        """Call the API with the specified project ID and build the project from JSON."""
         project_info = self._connector.get_project_by_id(project_id)
         project = ProjectImpl(project_id, project_info["name"])
         self._build_project_element(project)
@@ -74,7 +74,7 @@ class SysML2ProjectBuilder:
         self.extract_root_and_check_names(project)
 
     def extract_root_and_check_names(self, project: ProjectImpl):
-        """Parse all project elements, extract the root element and update names."""
+        """Parse all project elements, extract the root element, and update names."""
         roots = list()
         for _, element in project._env.items():
             setattr(element, "_name", SysMLUtil.check_inherited_name(element))
@@ -175,7 +175,7 @@ class SysML2ProjectBuilder:
             [setattr(element, getattr(x, "_name"), x) for x in all_element if hasattr(x, "_name")]
 
     def __get_all_element(self, element: SysMLElement) -> list:
-        """Parse all definitions from the element and return it's owned elements."""
+        """Parse all definitions from the element and return its owned elements."""
         all_element = getattr(element, "_ownedElement", [])
         all_element.extend(getattr(element, "_inheritedFeature", []))
         return all_element

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -30,7 +30,10 @@ from ansys.sam.sysml2.builder.classes.sysml_util import SysMLUtil
 from ansys.sam.sysml2.builder.json_mapper import JsonMapper
 from ansys.sam.sysml2.classes.project import Project
 from ansys.sam.sysml2.classes.sysml_element import SysMLElement
-from ansys.sam.sysml2.dto.query.constraints_classes import CompositeConstraint, PrimitiveConstraint
+from ansys.sam.sysml2.dto.query.constraints_classes import (
+    CompositeConstraint,
+    PrimitiveConstraint,
+)
 from ansys.sam.sysml2.dto.query.query_class import Query
 from ansys.sam.sysml2.dto.query.query_enum import JoinOperator
 from ansys.sam.sysml2.observer.observer import ModificationObserver
@@ -43,30 +46,11 @@ class SysML2ProjectBuilder:
     _mapper: JsonMapper = JsonMapper()
 
     def __init__(self, connector: SysML2APIConnector):
-        """
-        Construct a new instance.
-
-        Parameters
-        ----------
-        connector : SysML2APIConnector
-            SysML2 API connector.
-        """
+        """Construct a new instance with a specified SysML2APIConnector."""
         self._connector = connector
 
     def build_project(self, project_id: str) -> Project:
-        """
-        Call the API and build the project from JSON.
-
-        Parameters
-        ----------
-        project_id : str
-            Project ID.
-
-        Returns
-        -------
-        Project
-            Built project.
-        """
+        """Call the API with the specified project id and build the Project from JSON."""
         project_info = self._connector.get_project_by_id(project_id)
         project = ProjectImpl(project_id, project_info["name"])
         self._build_project_element(project)
@@ -76,14 +60,7 @@ class SysML2ProjectBuilder:
         return project
 
     def _build_project_element(self, project: ProjectImpl):
-        """
-        Build all project elements.
-
-        Parameters
-        ----------
-        project : ProjectImpl
-            Project to build.
-        """
+        """Build all project elements in the project."""
         elements = self._connector.get_all_elements(project_id=project._id)
         self._map_element_in_project(project, elements)
         missing_elements = self._resolve_fields(project)
@@ -97,17 +74,7 @@ class SysML2ProjectBuilder:
         self.extract_root_and_check_names(project)
 
     def extract_root_and_check_names(self, project: ProjectImpl):
-        """
-        Extract the root element and update names.
-
-        Parse all project elements and update names.
-        Also check if it's a root element.
-
-        Parameters
-        ----------
-        project : ProjectImpl
-            Context project.
-        """
+        """Parse all project elements, extract the root element and update names."""
         roots = list()
         for _, element in project._env.items():
             setattr(element, "_name", SysMLUtil.check_inherited_name(element))
@@ -208,19 +175,7 @@ class SysML2ProjectBuilder:
             [setattr(element, getattr(x, "_name"), x) for x in all_element if hasattr(x, "_name")]
 
     def __get_all_element(self, element: SysMLElement) -> list:
-        """
-        Parse all definitions and collect owned elements.
-
-        Parameters
-        ----------
-        element : SysMLElement
-            Base element.
-
-        Returns
-        -------
-        list
-            All owned elements.
-        """
+        """Parse all definitions from the element and return it's owned elements."""
         all_element = getattr(element, "_ownedElement", [])
         all_element.extend(getattr(element, "_inheritedFeature", []))
         return all_element
@@ -232,7 +187,7 @@ class SysML2ProjectBuilder:
             element._observer = project_modification_observer
 
     def _index_libraries(self, project: ProjectImpl):
-        """Index libraries for future reload."""
+        """Index libraries of the project for future reload."""
         libraries_elements = set()
         for _, element in project._env.items():
             if not getattr(element, "_qualifiedName", "").startswith(project._name):
@@ -240,7 +195,16 @@ class SysML2ProjectBuilder:
         project._libraries_ids = libraries_elements
 
     def reload_project(self, modification_observer: ModificationObserver, project: ProjectImpl):
-        """Reload the project and update elements."""
+        """
+        Reload the project and update all its elements.
+
+        Parameters
+        ----------
+        modification_observer : ModificationObserver
+            Observer instance.
+        project : ProjectImpl
+            Project instance to reload.
+        """
         modification_observer.stop_observer()
         self._build_project_element(project)
         self._resolve_inherited_link(project)

--- a/src/ansys/sam/sysml2/builder/sysml2_project_manager.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_manager.py
@@ -36,12 +36,12 @@ class SysML2ProjectManager:
     _constructed_project: Dict[(str, Project)]
 
     def __init__(self, connector: SysML2APIConnector):
-        """Construct a new instance with a specified SysML2APIConnector."""
+        """Construct a new instance with a specified SysML2 API Connector."""
         self._connector = connector
         self._constructed_project = dict()
 
     def get_project(self, project_id: str) -> Project:
-        """Get a project with its id from the API and map it in Python object."""
+        """Get a project with its ID from the API and map it in a Python object."""
         project = self._constructed_project.get(project_id, None)
         if project is None:
             project = SysML2ProjectBuilder(self._connector).build_project(project_id)

--- a/src/ansys/sam/sysml2/builder/sysml2_project_manager.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_manager.py
@@ -36,31 +36,12 @@ class SysML2ProjectManager:
     _constructed_project: Dict[(str, Project)]
 
     def __init__(self, connector: SysML2APIConnector):
-        """
-        Construct a new instance.
-
-        Parameters
-        ----------
-        connector : SysML2APIConnector
-            SysML2 API connector.
-        """
+        """Construct a new instance with a specified SysML2APIConnector."""
         self._connector = connector
         self._constructed_project = dict()
 
     def get_project(self, project_id: str) -> Project:
-        """
-        Get a project from the API to load into a Python object.
-
-        Parameters
-        ----------
-        project_id : str
-            Project ID.
-
-        Returns
-        -------
-        Project
-            Mapped project.
-        """
+        """Get a project with its id from the API and map it in Python object."""
         project = self._constructed_project.get(project_id, None)
         if project is None:
             project = SysML2ProjectBuilder(self._connector).build_project(project_id)

--- a/src/ansys/sam/sysml2/classes/http_request.py
+++ b/src/ansys/sam/sysml2/classes/http_request.py
@@ -36,12 +36,5 @@ class HttpRequest:
     cookies: dict = field(default_factory=dict)
 
     def explode(self) -> dict:
-        """
-        Get all information for building an HTTP request.
-
-        Returns
-        -------
-        dict
-            Information.
-        """
+        """Get all information for building an HTTP request."""
         return dict((x, y) for x, y in self.__dict__.items() if not x.startswith("_"))

--- a/src/ansys/sam/sysml2/classes/mapped_element.py
+++ b/src/ansys/sam/sysml2/classes/mapped_element.py
@@ -49,23 +49,9 @@ class MappedElement:
         self._unresolved_fields = unresolved_fields
 
     def get_element(self) -> SysMLElement:
-        """
-        Get the mapped element.
-
-        Returns
-        -------
-        SysMLElement
-            Mapped element.
-        """
+        """Get the mapped element."""
         return self._element
 
     def get_unresolved_fields(self) -> List[UnresolvedField]:
-        """
-        Get a list of all unresolved fields.
-
-        Returns
-        -------
-        List[UnresolvedField]
-            List of all unresolved fields.
-        """
+        """Get a list of all unresolved fields."""
         return self._unresolved_fields

--- a/src/ansys/sam/sysml2/classes/project.py
+++ b/src/ansys/sam/sysml2/classes/project.py
@@ -31,14 +31,7 @@ class Project:
     """Provides the project interface for users."""
 
     def get_root(self) -> List[SysMLElement]:
-        """
-        Get a list of root packages.
-
-        Returns
-        -------
-        List[SysMLElement]
-            List of root elements.
-        """
+        """Get a list of root packages."""
         return []
 
     def get_root_package(self) -> SysMLElement:

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -36,13 +36,7 @@ class SysMLElement:
     _observer: ModificationObserver = None
 
     def __init__(self, id: str) -> None:
-        """Construct a new instance.
-
-        Parameters
-        ----------
-        id : str
-            Element ID.
-        """
+        """Construct a new SysMLElement instance with its id specified."""
         self._id = id
 
     def __setattr__(self, name: str, value: object):
@@ -163,11 +157,29 @@ class SysMLElement:
         self.__set_or_update_value(type(new_value), new_value)
 
     def __set_or_update_value(self, value_type: type, new_value: Union[str | int | float | bool]):
-        """Create the commit to update the value of type ``value_type``."""
+        """
+        Create the commit to create or update the value of type ``value_type``.
+
+        Parameters
+        ----------
+        value_type : type
+            Value type of the new value.
+        new_value : Union[str | int | float | bool]
+            New value to be updated.
+        """
         self._create_value(value_type, new_value)
 
     def _create_value(self, value_type: type, new_value: Union[str | int | float | bool]):
-        """Create a new value of type ``value_type`` in the feature."""
+        """
+        Create a new value of type ``value_type`` in the feature.
+
+        Parameters
+        ----------
+        value_type : type
+            Value type of the new value.
+        new_value : Union[str | int | float | bool]
+            New value to be created.
+        """
         project_id = self._observer._project_id
         commit = Commit(project_id)
         change = DataVersion()

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -36,7 +36,7 @@ class SysMLElement:
     _observer: ModificationObserver = None
 
     def __init__(self, id: str) -> None:
-        """Construct a new SysMLElement instance with its id specified."""
+        """Construct a new SysML element instance with its ID specified."""
         self._id = id
 
     def __setattr__(self, name: str, value: object):
@@ -158,14 +158,14 @@ class SysMLElement:
 
     def __set_or_update_value(self, value_type: type, new_value: Union[str | int | float | bool]):
         """
-        Create the commit to create or update the value of type ``value_type``.
+        Create the commit to set or update the value of type ``value_type``.
 
         Parameters
         ----------
         value_type : type
             Value type of the new value.
         new_value : Union[str | int | float | bool]
-            New value to be updated.
+            New value to update to.
         """
         self._create_value(value_type, new_value)
 
@@ -178,7 +178,7 @@ class SysMLElement:
         value_type : type
             Value type of the new value.
         new_value : Union[str | int | float | bool]
-            New value to be created.
+            New value to create.
         """
         project_id = self._observer._project_id
         commit = Commit(project_id)

--- a/src/ansys/sam/sysml2/classes/unresolved_field.py
+++ b/src/ansys/sam/sysml2/classes/unresolved_field.py
@@ -50,14 +50,7 @@ class UnresolvedField:
         self._element_id = element_id
 
     def get_id(self) -> str:
-        """
-        Get the missing element ID.
-
-        Returns
-        -------
-        str
-            Missing element ID.
-        """
+        """Get the missing element ID."""
         return self._element_id
 
     def resolve(self, element: SysMLElement):

--- a/src/ansys/sam/sysml2/diagrams/api/sam_api_connector.py
+++ b/src/ansys/sam/sysml2/diagrams/api/sam_api_connector.py
@@ -37,20 +37,65 @@ class SamApiConnector(ABC):
 
     @abstractmethod
     def get_single_diagram_info(self, project_id: str, diagram_id: str) -> dict:
-        """Get detailed information for a single diagram within a project."""
+        """
+        Get detailed information for a single diagram within a project.
+
+        Parameters
+        ----------
+        project_id: str
+            Project ID of the project containing the diagram.
+        diagram_id: str
+            Diagram ID of the diagram you want to get information on.
+        """
 
     @abstractmethod
     def get_diagram_image_as_svg(self, project_id: str, diagram_id: str) -> bytes:
-        """Download a diagram rendered as SVG format."""
+        """
+        Download a diagram rendered as SVG format.
+
+        Parameters
+        ----------
+        project_id: str
+            Project ID of the project containing the diagram.
+        diagram_id: str
+            Diagram ID of the diagram you want to download.
+        """
 
     @abstractmethod
     def get_diagram_image_as_png(self, project_id: str, diagram_id: str) -> bytes:
-        """Download a diagram rendered as PNG format."""
+        """
+        Download a diagram rendered as PNG format.
+
+        Parameters
+        ----------
+        project_id: str
+            Project ID of the project containing the diagram.
+        diagram_id: str
+            Diagram ID of the diagram you want to download.
+        """
 
     @abstractmethod
     def get_diagram_image_as_jpeg(self, project_id: str, diagram_id: str) -> bytes:
-        """Download a diagram rendered as JPEG format."""
+        """
+        Download a diagram rendered as JPEG format.
+
+        Parameters
+        ----------
+        project_id: str
+            Project ID of the project containing the diagram.
+        diagram_id: str
+            Diagram ID of the diagram you want to download.
+        """
 
     @abstractmethod
     def get_all_diagram_image_from_project(self, project_id: str, file_format: str) -> bytes:
-        """Download all diagrams from a project as a compressed ZIP archive."""
+        """
+        Download all diagrams from a project as a compressed ZIP archive.
+
+        Parameters
+        ----------
+        project_id: str
+            Project ID of the project containing the diagram.
+        file_format: str
+            File format of the diagram images contained in the ZIP archive.
+        """

--- a/src/ansys/sam/sysml2/diagrams/api/sam_api_connector.py
+++ b/src/ansys/sam/sysml2/diagrams/api/sam_api_connector.py
@@ -45,7 +45,7 @@ class SamApiConnector(ABC):
         project_id: str
             Project ID of the project containing the diagram.
         diagram_id: str
-            Diagram ID of the diagram you want to get information on.
+            Diagram ID of the diagram to get information on.
         """
 
     @abstractmethod
@@ -58,7 +58,7 @@ class SamApiConnector(ABC):
         project_id: str
             Project ID of the project containing the diagram.
         diagram_id: str
-            Diagram ID of the diagram you want to download.
+            Diagram ID of the diagram to download.
         """
 
     @abstractmethod
@@ -71,7 +71,7 @@ class SamApiConnector(ABC):
         project_id: str
             Project ID of the project containing the diagram.
         diagram_id: str
-            Diagram ID of the diagram you want to download.
+            Diagram ID of the diagram to download.
         """
 
     @abstractmethod
@@ -84,7 +84,7 @@ class SamApiConnector(ABC):
         project_id: str
             Project ID of the project containing the diagram.
         diagram_id: str
-            Diagram ID of the diagram you want to download.
+            Diagram ID of the diagram to download.
         """
 
     @abstractmethod

--- a/src/ansys/sam/sysml2/diagrams/api/sam_rest_api_connector.py
+++ b/src/ansys/sam/sysml2/diagrams/api/sam_rest_api_connector.py
@@ -78,7 +78,7 @@ class SamRestApiConnector(SamApiConnector):
         project_id: str
             Project ID of the project containing the diagram.
         diagram_id: str
-            Diagram ID of the diagram you want to get information on.
+            Diagram ID of the diagram to get information on.
         """
         http_request = self._build_image_http_request(
             endpoint=f"/projects/{project_id}/diagrams/{diagram_id}"
@@ -94,7 +94,7 @@ class SamRestApiConnector(SamApiConnector):
         project_id: str
             Project ID of the project containing the diagram.
         diagram_id: str
-            Diagram ID of the diagram you want to download.
+            Diagram ID of the diagram to download.
         """
         http_request = self._build_image_http_request(
             endpoint=f"/projects/{project_id}/diagrams/{diagram_id}/svg"
@@ -110,7 +110,7 @@ class SamRestApiConnector(SamApiConnector):
         project_id: str
             Project ID of the project containing the diagram.
         diagram_id: str
-            Diagram ID of the diagram you want to download.
+            Diagram ID of the diagram to download.
         """
         http_request = self._build_image_http_request(
             endpoint=f"/projects/{project_id}/diagrams/{diagram_id}/png"
@@ -126,7 +126,7 @@ class SamRestApiConnector(SamApiConnector):
         project_id: str
             Project ID of the project containing the diagram.
         diagram_id: str
-            Diagram ID of the diagram you want to download.
+            Diagram ID of the diagram to download.
         """
         http_request = self._build_image_http_request(
             endpoint=f"/projects/{project_id}/diagrams/{diagram_id}/jpeg"
@@ -158,7 +158,7 @@ class SamRestApiConnector(SamApiConnector):
         http_request : HttpRequest
             Request object containing URL, headers, and body.
         call : Callable
-            HTTP method function (e.g., requests.get, requests.post).
+            HTTP method function (such a ``requests.get`` or ``requests.post``).
 
         Returns
         -------
@@ -197,14 +197,14 @@ class SamRestApiConnector(SamApiConnector):
         http_request : HttpRequest
             Request object containing URL, headers, and body.
         call : Callable
-            HTTP method function (e.g., requests.get, requests.post).
-        stream : bool, optional
-            If True, return the response object for streaming. Default is False.
+            HTTP method function (such a ``requests.get`` or ``requests.post``).
+        stream : bool, default: False
+            Whether to return the response object for streaming.
 
         Returns
         -------
         bytes or requests.Response
-            Binary content if stream is False, otherwise the response object.
+            Binary content if the stream is ``False``. Otherwise, the response object.
 
         Raises
         ------

--- a/src/ansys/sam/sysml2/diagrams/api/sam_rest_api_connector.py
+++ b/src/ansys/sam/sysml2/diagrams/api/sam_rest_api_connector.py
@@ -41,7 +41,18 @@ class SamRestApiConnector(SamApiConnector):
     _server_url: str
 
     def __init__(self, server_url: str, token: str, use_ssl: bool = True):
-        """Initialize the connector with a server URL and authentication token."""
+        """
+        Initialize the connector with a server URL and authentication token.
+
+        Parameters
+        ----------
+        server_url : str
+            Server URL.
+        token : str
+            Authentication token.
+        use_ssl : bool, default: True
+            Whether the server URL uses SSL (valid HTTPS).
+        """
         if server_url.endswith("/"):
             server_url = server_url[:-1]
         self._server_url = server_url
@@ -59,42 +70,108 @@ class SamRestApiConnector(SamApiConnector):
         return self._send_request(http_request=http_request, call=requests.get)
 
     def get_single_diagram_info(self, project_id: str, diagram_id: str) -> dict:
-        """Get detailed information for a single diagram within a project."""
+        """
+        Get detailed information for a single diagram within a project.
+
+        Parameters
+        ----------
+        project_id: str
+            Project ID of the project containing the diagram.
+        diagram_id: str
+            Diagram ID of the diagram you want to get information on.
+        """
         http_request = self._build_image_http_request(
             endpoint=f"/projects/{project_id}/diagrams/{diagram_id}"
         )
         return self._send_request(http_request=http_request, call=requests.get)
 
     def get_diagram_image_as_svg(self, project_id: str, diagram_id: str) -> bytes:
-        """Download a diagram rendered as SVG format."""
+        """
+        Download a diagram rendered as SVG format.
+
+        Parameters
+        ----------
+        project_id: str
+            Project ID of the project containing the diagram.
+        diagram_id: str
+            Diagram ID of the diagram you want to download.
+        """
         http_request = self._build_image_http_request(
             endpoint=f"/projects/{project_id}/diagrams/{diagram_id}/svg"
         )
         return self._send_request_binary(http_request=http_request, call=requests.get)
 
     def get_diagram_image_as_png(self, project_id: str, diagram_id: str) -> bytes:
-        """Download a diagram rendered as PNG format."""
+        """
+        Download a diagram rendered as PNG format.
+
+        Parameters
+        ----------
+        project_id: str
+            Project ID of the project containing the diagram.
+        diagram_id: str
+            Diagram ID of the diagram you want to download.
+        """
         http_request = self._build_image_http_request(
             endpoint=f"/projects/{project_id}/diagrams/{diagram_id}/png"
         )
         return self._send_request_binary(http_request=http_request, call=requests.get)
 
     def get_diagram_image_as_jpeg(self, project_id: str, diagram_id: str) -> bytes:
-        """Download a diagram rendered as JPEG format."""
+        """
+        Download a diagram rendered as JPEG format.
+
+        Parameters
+        ----------
+        project_id: str
+            Project ID of the project containing the diagram.
+        diagram_id: str
+            Diagram ID of the diagram you want to download.
+        """
         http_request = self._build_image_http_request(
             endpoint=f"/projects/{project_id}/diagrams/{diagram_id}/jpeg"
         )
         return self._send_request_binary(http_request=http_request, call=requests.get)
 
     def get_all_diagram_image_from_project(self, project_id: str, file_format: str) -> bytes:
-        """Download all diagrams from a project as a compressed ZIP archive."""
+        """
+        Download all diagrams from a project as a compressed ZIP archive.
+
+        Parameters
+        ----------
+        project_id: str
+            Project ID of the project containing the diagram.
+        file_format: str
+            File format of the diagram images contained in the ZIP archive.
+        """
         http_request = self._build_image_http_request(
             endpoint=f"/projects/{project_id}/diagrams/all/{file_format}"
         )
         return self._send_request_binary(http_request=http_request, call=requests.get, stream=True)
 
     def _send_request(self, http_request: HttpRequest, call: Callable) -> object:
-        """Send an HTTP request and parse JSON response with error handling."""
+        """
+        Send an HTTP request and parse JSON response with error handling.
+
+        Parameters
+        ----------
+        http_request : HttpRequest
+            Request object containing URL, headers, and body.
+        call : Callable
+            HTTP method function (e.g., requests.get, requests.post).
+
+        Returns
+        -------
+        object
+            Parsed JSON response as a Python object.
+
+        Raises
+        ------
+        ConnectorConnectionException
+            If the connection fails.
+        InvalidElementJsonFoundException
+            If the response contains invalid JSON.
+        """
         response = None
         try:
             response = call(**http_request.explode(), verify=self._use_ssl)
@@ -112,7 +189,28 @@ class SamRestApiConnector(SamApiConnector):
     def _send_request_binary(
         self, http_request: HttpRequest, call: Callable, stream: bool = False
     ) -> Union[bytes, requests.Response]:
-        """Send an HTTP request and return binary content or response object for file downloads."""
+        """
+        Send an HTTP request and return binary content or response object.
+
+        Parameters
+        ----------
+        http_request : HttpRequest
+            Request object containing URL, headers, and body.
+        call : Callable
+            HTTP method function (e.g., requests.get, requests.post).
+        stream : bool, optional
+            If True, return the response object for streaming. Default is False.
+
+        Returns
+        -------
+        bytes or requests.Response
+            Binary content if stream is False, otherwise the response object.
+
+        Raises
+        ------
+        ConnectorConnectionException
+            If the connection or request fails.
+        """
         try:
             response = call(**http_request.explode(), verify=self._use_ssl, stream=stream)
             response.raise_for_status()

--- a/src/ansys/sam/sysml2/diagrams/builder/emf_json_mapper.py
+++ b/src/ansys/sam/sysml2/diagrams/builder/emf_json_mapper.py
@@ -263,7 +263,7 @@ class EMFJSONMapper:
         items : list
             List containing dictionaries or simple values.
         owner : DiagramElement
-            Oobject that owns the attribute being set.
+            Object that owns the attribute being set.
         attr : str
             Name of the attribute on the owner.
         original_key : str, default: None

--- a/src/ansys/sam/sysml2/diagrams/builder/sam_diagram_builder.py
+++ b/src/ansys/sam/sysml2/diagrams/builder/sam_diagram_builder.py
@@ -35,12 +35,12 @@ class SamDiagramBuilder:
     _mapper: EMFJSONMapper
 
     def __init__(self, connector: SamApiConnector):
-        """Construct a new instance."""
+        """Construct a new instance with SamApiConnector instance specified."""
         self._connector = connector
         self._mapper = EMFJSONMapper()
 
     def extract_and_build_diagrams(self, project: Project) -> dict:
-        """Extract and build all diagrams from model data."""
+        """Extract and build all diagrams from a project."""
         data = self._connector.get_project_data(project._id)
         diagrams_extracted = self.__extract_diagrams(data)
         return self.__build_diagrams(diagrams_extracted, project)
@@ -50,7 +50,21 @@ class SamDiagramBuilder:
         return self.__filter_diagrams(self.__extract_e_annotations(data))
 
     def __build_diagrams(self, diagrams_extracted: dict, project: Project) -> dict:
-        """Build all diagram elements."""
+        """
+        Build all diagram elements from extracted annotations.
+
+        Parameters
+        ----------
+        diagrams_extracted : dict
+            Dictionary mapping diagram IDs to their annotation lists.
+        project : Project
+            Project instance used for resolving unresolved fields.
+
+        Returns
+        -------
+        dict
+            Dictionary mapping diagram IDs to their built element lists.
+        """
         data = {}
         for id, annotations in diagrams_extracted.items():
             elements = []

--- a/src/ansys/sam/sysml2/diagrams/builder/sam_diagram_builder.py
+++ b/src/ansys/sam/sysml2/diagrams/builder/sam_diagram_builder.py
@@ -35,7 +35,7 @@ class SamDiagramBuilder:
     _mapper: EMFJSONMapper
 
     def __init__(self, connector: SamApiConnector):
-        """Construct a new instance with SamApiConnector instance specified."""
+        """Construct a new instance with the SAM API Connector instance specified."""
         self._connector = connector
         self._mapper = EMFJSONMapper()
 

--- a/src/ansys/sam/sysml2/diagrams/classes/diagram_element.py
+++ b/src/ansys/sam/sysml2/diagrams/classes/diagram_element.py
@@ -28,5 +28,5 @@ class DiagramElement:
     _id: str
 
     def __init__(self, id: str):
-        """Construct a new diagram instance with its id provided."""
+        """Construct a new diagram instance with its ID provided."""
         self._id = id

--- a/src/ansys/sam/sysml2/diagrams/classes/diagram_element.py
+++ b/src/ansys/sam/sysml2/diagrams/classes/diagram_element.py
@@ -28,12 +28,5 @@ class DiagramElement:
     _id: str
 
     def __init__(self, id: str):
-        """
-        Construct a new diagram instance.
-
-        Parameters
-        ----------
-        id : str
-            Diagram ID.
-        """
+        """Construct a new diagram instance with its id provided."""
         self._id = id

--- a/src/ansys/sam/sysml2/diagrams/sam_diagram_manager.py
+++ b/src/ansys/sam/sysml2/diagrams/sam_diagram_manager.py
@@ -35,7 +35,7 @@ class SAMDiagramManager:
     _connector: SamApiConnector
 
     def __init__(self, connector: SamApiConnector):
-        """Construct a new instance with SamApiConnector instance specified."""
+        """Construct a new instance with the SAM API Connector instance specified."""
         self._connector = connector
 
     def __enter__(self):

--- a/src/ansys/sam/sysml2/diagrams/sam_diagram_manager.py
+++ b/src/ansys/sam/sysml2/diagrams/sam_diagram_manager.py
@@ -35,7 +35,7 @@ class SAMDiagramManager:
     _connector: SamApiConnector
 
     def __init__(self, connector: SamApiConnector):
-        """Construct a new instance."""
+        """Construct a new instance with SamApiConnector instance specified."""
         self._connector = connector
 
     def __enter__(self):

--- a/src/ansys/sam/sysml2/dto/commit/data_version.py
+++ b/src/ansys/sam/sysml2/dto/commit/data_version.py
@@ -38,7 +38,16 @@ class DataVersion:
         self.identity = element_id
 
     def add_change(self, key: str, value: Any):
-        """Add the change into the data version. Also serialize the data if it's needed."""
+        """
+        Add the change into the data version. Also serialize the data if it's needed.
+
+        Parameters
+        ----------
+        key: str
+            Key of the change.
+        value: Any
+            Value of the change.
+        """
         from ansys.sam.sysml2.classes.sysml_element import SysMLElement
         from ansys.sam.sysml2.data_structures.observed_list import ObservedList
 

--- a/src/ansys/sam/sysml2/dto/query/constraints_classes.py
+++ b/src/ansys/sam/sysml2/dto/query/constraints_classes.py
@@ -33,14 +33,7 @@ class Constraint:
     """Provides the constraint interface."""
 
     def to_json(self) -> dict:
-        """
-        Return a JSON representation of the class.
-
-        Returns
-        -------
-        dict
-            Class adapted to JSON format.
-        """
+        """Return a JSON representation of the class."""
         data = {"@type": self.__class__.__name__}
         data.update(dict((k, v) for k, v in self.__dict__.items() if not k.startswith("_")))
         return data
@@ -64,14 +57,7 @@ class CompositeConstraint(Constraint):
     constraint: List[Constraint] = field(default_factory=list)
 
     def to_json(self) -> dict:
-        """
-        Get a JSON representation of the class.
-
-        Returns
-        -------
-        dict
-            Class adapted to JSON format.
-        """
+        """Get a JSON representation of the class."""
         data = super().to_json()
         end_data = data.copy()
         end_data["constraint"] = list()

--- a/src/ansys/sam/sysml2/dto/query/query_class.py
+++ b/src/ansys/sam/sysml2/dto/query/query_class.py
@@ -34,12 +34,5 @@ class Query:
     where: Constraint = None
 
     def to_json(self) -> str:
-        """
-        Get a JSON representation of the class.
-
-        Returns
-        -------
-        str
-            Class adapted to JSON format.
-        """
+        """Get a JSON representation of the class."""
         return dumps({"@type": "Query", "where": self.where.to_json()})

--- a/src/ansys/sam/sysml2/observer/observer.py
+++ b/src/ansys/sam/sysml2/observer/observer.py
@@ -35,7 +35,16 @@ class ModificationObserver:
     _connector: SysML2APIConnector
 
     def __init__(self, project, connector: SysML2APIConnector):
-        """Construct a new instance."""
+        """
+        Construct a new instance.
+
+        Parameters
+        ----------
+        project : ProjectImpl
+            Project instance to be observed.
+        connector: SysML2APIConnector
+            SysML2 API Connector to make API calls.
+        """
         self._project_id = project._id
         self._project = project
         self._connector = connector
@@ -66,18 +75,18 @@ class ModificationObserver:
             self._connector.create_commit(self._project_id, commit.to_json())
             self.reload_project()
 
-    def list_notify(self, element_id, name, list_content):
+    def list_notify(self, element_id: str, name: str, list_content):
         """
         Catch modification on a list.
 
         Parameters
         ----------
-        element_id : _type_
-            _description_
-        name : _type_
-            _description_
-        list_content : _type_
-            _description_
+        element_id : str
+            Modified element ID.
+        name : str
+            Key of the modified field.
+        list_content : Any
+            Updated content of the modified list field.
         """
         if self._working_observer:
             commit = Commit(self._project_id)

--- a/src/ansys/sam/sysml2/observer/observer.py
+++ b/src/ansys/sam/sysml2/observer/observer.py
@@ -41,7 +41,7 @@ class ModificationObserver:
         Parameters
         ----------
         project : ProjectImpl
-            Project instance to be observed.
+            Project instance to observe.
         connector: SysML2APIConnector
             SysML2 API Connector to make API calls.
         """

--- a/src/ansys/sam/sysml2/tools/ansys_sysml2_project.py
+++ b/src/ansys/sam/sysml2/tools/ansys_sysml2_project.py
@@ -100,7 +100,20 @@ class AnsysSysML2Project(ProjectImpl):
         organization_id: str,
         use_ssl: bool = True,
     ) -> None:
-        """Initialize all internal components and establish connections."""
+        """
+        Initialize all internal components and establish connections.
+
+        Parameters
+        ----------
+        server_url : str
+            Base URL of the SysML2 server.
+        token : str
+            Authentication token for API access.
+        organization_id : str
+            Unique ID of the organization.
+        use_ssl : bool, default: True
+            Whether to use SSL/TLS for connections.
+        """
         sysml2_connector = AnsysSysML2APIConnector(
             server_url=server_url,
             organization_id=organization_id,

--- a/src/ansys/sam/sysml2/tools/factory.py
+++ b/src/ansys/sam/sysml2/tools/factory.py
@@ -35,7 +35,15 @@ class Factory:
     _conn: AnsysSysML2APIConnector
 
     def __init__(self, project: Project, conn: AnsysSysML2APIConnector) -> None:
-        """Initialize a new instance."""
+        """Initialize a new instance.
+
+        Parameters
+        ----------
+        project: Project
+            Project to be modified by the factory.
+        conn: AnsysSysML2APIConnector
+            Connector to make API calls.
+        """
         self._project_id = project._id
         self._project = project
         self._conn = conn


### PR DESCRIPTION
- Use NumPy-style format for multi-parameter functions
- Use concise inline descriptions for single-parameter functions
  where the parameter is self-explanatory
- Ensure consistency with existing documentation