### PR TITLE
fix: separate project manager cache for scripting and SysML project types

### DIFF
--- a/doc/changelog.d/155.fixed.md
+++ b/doc/changelog.d/155.fixed.md
@@ -1,0 +1,1 @@
+Separate project manager cache for scripting and SysML project types

--- a/src/ansys/sam/sysml2/builder/sysml2_project_manager.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_manager.py
@@ -34,12 +34,14 @@ class SysML2ProjectManager:
     """Provides the director class for loading and managing projects."""
 
     _connector: SysML2APIConnector
-    _constructed_project: Dict[(str, ScriptingProject)]
+    _scripting_projects: Dict[str, ScriptingProject]
+    _sysml_projects: Dict[str, Project]
 
     def __init__(self, connector: SysML2APIConnector):
         """Construct a new instance with a specified SysML2 API Connector."""
         self._connector = connector
-        self._constructed_project = dict()
+        self._scripting_projects = dict()
+        self._sysml_projects = dict()
 
     def get_projects(self) -> List[dict]:
         """
@@ -54,18 +56,18 @@ class SysML2ProjectManager:
 
     def get_sysml_project(self, project_id: str) -> Project:
         """Get a SysML project with its ID from the API and map it in a Python object."""
-        project = self._constructed_project.get(project_id, None)
+        project = self._sysml_projects.get(project_id, None)
         if project is None:
             project = SysML2ProjectBuilder(self._connector).build_sysml_project(project_id)
-            self._constructed_project[project_id] = project
+            self._sysml_projects[project_id] = project
         return project
 
     def get_scripting_project(self, project_id: str) -> ScriptingProject:
         """Get a scripting project with its ID from the API and map it in a Python object."""
-        project = self._constructed_project.get(project_id, None)
+        project = self._scripting_projects.get(project_id, None)
         if project is None:
             project = SysML2ProjectBuilder(self._connector).build_scripting_project(project_id)
-            self._constructed_project[project_id] = project
+            self._scripting_projects[project_id] = project
         return project
 
     def create_sysml_project(
@@ -91,7 +93,7 @@ class SysML2ProjectManager:
         project_data = self._connector.create_project(name, description)
         project_id = project_data["@id"]
         project = SysML2ProjectBuilder(self._connector).build_sysml_project(project_id)
-        self._constructed_project[project_id] = project
+        self._sysml_projects[project_id] = project
         return project
 
     def create_scripting_project(
@@ -117,7 +119,7 @@ class SysML2ProjectManager:
         project_data = self._connector.create_project(name, description)
         project_id = project_data["@id"]
         project = SysML2ProjectBuilder(self._connector).build_scripting_project(project_id)
-        self._constructed_project[project_id] = project
+        self._scripting_projects[project_id] = project
         return project
 
     def delete_project(self, project_id: str) -> dict:
@@ -135,7 +137,8 @@ class SysML2ProjectManager:
             Confirmation containing ``@type`` and ``@id`` of the deleted project.
         """
         result = self._connector.delete_project(project_id)
-        self._constructed_project.pop(project_id, None)
+        self._scripting_projects.pop(project_id, None)
+        self._sysml_projects.pop(project_id, None)
         return result
 
     def update_project(
@@ -162,5 +165,6 @@ class SysML2ProjectManager:
             Updated project record.
         """
         result = self._connector.update_project(project_id, name, description)
-        self._constructed_project.pop(project_id, None)
+        self._scripting_projects.pop(project_id, None)
+        self._sysml_projects.pop(project_id, None)
         return result

--- a/tests/sam/sysml2/builder/test_sysml2_project_manager.py
+++ b/tests/sam/sysml2/builder/test_sysml2_project_manager.py
@@ -82,3 +82,12 @@ class TestSysML2ProjectManager(ParentTestClass):
         manager = SysML2ProjectManager(valid_source)
         with pytest.raises(ProjectNotFoundException):
             manager.update_project("non_existent_id", name="NewName")
+
+    def test_dual_mode_cache_override(self, valid_source: AnsysSysML2APIConnector):
+        """Loading same project as scripting then sysml must return different types."""
+        manager = SysML2ProjectManager(valid_source)
+        scripting = manager.get_scripting_project(PROJECT_ID_1)
+        sysml = manager.get_sysml_project(PROJECT_ID_1)
+        assert type(scripting).__name__ == "ScriptingProjectImpl"
+        assert type(sysml).__name__ == "ProjectImpl"
+        assert type(scripting) != type(sysml)

--- a/tests/sam/sysml2/builder/test_sysml2_project_manager.py
+++ b/tests/sam/sysml2/builder/test_sysml2_project_manager.py
@@ -52,12 +52,12 @@ class TestSysML2ProjectManager(ParentTestClass):
     def test_delete_project(self, valid_source: AnsysSysML2APIConnector):
         manager = SysML2ProjectManager(valid_source)
         manager.get_scripting_project(PROJECT_ID_1)
-        assert PROJECT_ID_1 in manager._constructed_project
+        assert PROJECT_ID_1 in manager._scripting_projects
 
         result = manager.delete_project(PROJECT_ID_1)
         assert result is not None
         assert result["@id"] == PROJECT_ID_1
-        assert PROJECT_ID_1 not in manager._constructed_project
+        assert PROJECT_ID_1 not in manager._scripting_projects
 
     def test_delete_project_not_found(self, valid_source: AnsysSysML2APIConnector):
         manager = SysML2ProjectManager(valid_source)
@@ -67,7 +67,7 @@ class TestSysML2ProjectManager(ParentTestClass):
     def test_update_project(self, valid_source: AnsysSysML2APIConnector):
         manager = SysML2ProjectManager(valid_source)
         manager.get_scripting_project(PROJECT_ID_1)
-        assert PROJECT_ID_1 in manager._constructed_project
+        assert PROJECT_ID_1 in manager._scripting_projects
 
         result = manager.update_project(
             PROJECT_ID_1, name="NewName", description="NewDesc"
@@ -76,7 +76,7 @@ class TestSysML2ProjectManager(ParentTestClass):
         assert result["@id"] == PROJECT_ID_1
         assert result["name"] == "NewName"
         assert result["description"] == "NewDesc"
-        assert PROJECT_ID_1 not in manager._constructed_project
+        assert PROJECT_ID_1 not in manager._scripting_projects
 
     def test_update_project_not_found(self, valid_source: AnsysSysML2APIConnector):
         manager = SysML2ProjectManager(valid_source)


### PR DESCRIPTION
Issue:  #153