### PR TITLE
docs: fix example title and add project management guide

### DIFF
--- a/doc/changelog.d/157.documentation.md
+++ b/doc/changelog.d/157.documentation.md
@@ -1,0 +1,1 @@
+Fix example title and add project management guide

--- a/doc/source/_static/code/manage-projects.py
+++ b/doc/source/_static/code/manage-projects.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Example showing project management: create, list, update, and delete projects."""
+
+import requests
+from urllib3.exceptions import InsecureRequestWarning
+
+from ansys.sam.sysml2 import AnsysSysML2APIConnector, SysML2ProjectManager
+
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
+# Create your connector for the SAM Server
+connector = AnsysSysML2APIConnector(
+    server_url="<SAM Server URL>",  # Your SAM server base URL
+    organization_id="<Orga ID>",  # The organization ID
+    token="<Token>",  # Your authorization token
+    use_ssl=False,  # If the server hasn't a valid SSL
+)
+
+project_manager = SysML2ProjectManager(connector=connector)
+
+# --- List all existing projects ---
+projects = project_manager.get_projects()
+print(f"Found {len(projects)} project(s):")
+for p in projects:
+    print(f"  - {p['name']} (id: {p['@id']})")
+
+# --- Create a new project ---
+my_project = project_manager.create_scripting_project(
+    name="My New Project",
+    description="A project created via PySAM SysML2",
+)
+project_id = my_project.get_id()
+print(f"\nCreated project: {my_project.get_name()} (id: {project_id})")
+
+# --- Update the project ---
+updated = project_manager.update_project(
+    project_id=project_id,
+    name="My Renamed Project",
+    description="Updated description",
+)
+print(f"\nUpdated project: {updated['name']} - {updated['description']}")
+
+# --- Delete the project ---
+deleted = project_manager.delete_project(project_id=project_id)
+print(f"\nDeleted project with id: {deleted['@id']}")

--- a/doc/source/examples/download-diagrams.rst
+++ b/doc/source/examples/download-diagrams.rst
@@ -1,7 +1,7 @@
 .. _Download_Example:
 
-Download diagrams and create new elements
-#########################################
+Download diagrams and navigate elements
+#######################################
 
 This example shows how to work with the ``Bike`` model in a SysML v2 project using the
 Ansys SAM API. It explains how to perform these tasks:

--- a/doc/source/examples/index.rst
+++ b/doc/source/examples/index.rst
@@ -7,7 +7,7 @@ This section provides some examples of how to use PySAM SysML2.
 
 .. only:: html
 
-    .. grid:: 5
+    .. grid:: 3
 
         .. grid-item-card:: Calculate bike weight :fa:`bicycle`
             :link: bike-weight
@@ -27,6 +27,8 @@ This section provides some examples of how to use PySAM SysML2.
 
             Create new elements in your project.
 
+    .. grid:: 3
+
         .. grid-item-card:: Download diagrams :fa:`download`
             :link: download-diagrams
             :link-type: doc
@@ -39,6 +41,12 @@ This section provides some examples of how to use PySAM SysML2.
 
             Streamline SAM project initialization and operations.
 
+        .. grid-item-card:: Manage projects :fa:`folder-open`
+            :link: manage-projects
+            :link-type: doc
+
+            Create, update, and delete projects on the server.
+
 .. toctree::
    :maxdepth: 4
    :hidden:
@@ -48,3 +56,4 @@ This section provides some examples of how to use PySAM SysML2.
    creating-elements
    download-diagrams
    simplified-sam-project
+   manage-projects

--- a/doc/source/examples/manage-projects.rst
+++ b/doc/source/examples/manage-projects.rst
@@ -1,0 +1,40 @@
+.. _Manage_Projects_Example:
+
+Manage projects
+###############
+
+This example shows how to manage SysML v2 projects on a SAM server using the
+:class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>`
+class. It explains how to perform these tasks:
+
+- List all existing projects.
+- Create a new project.
+- Update a project name and description.
+- Delete a project.
+
+.. note::
+
+    For more details on each operation, see the user guide page
+    :ref:`Manage projects <Manage_Projects_Section>`.
+
+Prerequisites
+=============
+
+Ensure that you meet these prerequisites:
+
+- A running SAM server instance.
+- A valid organization ID and token.
+
+Python example
+==============
+
+.. literalinclude:: ../_static/code/manage-projects.py
+    :language: python
+    :caption: Project management: create, list, update, and delete projects
+    :linenos:
+
+.. note::
+
+    - Replace placeholder values with your actual SAM configuration.
+    - Deleting a project is irreversible. All data associated with the project is permanently
+      removed.

--- a/doc/source/examples/simplified-sam-project.rst
+++ b/doc/source/examples/simplified-sam-project.rst
@@ -59,7 +59,7 @@ Key advantages
 ==============
 
 Compared to the traditional approach described in
-:ref:`Download diagrams and create new elements<Download_Example>`, using the simplified
+:ref:`Download diagrams and navigate elements<Download_Example>`, using the simplified
 :class:`AnsysSysML2Project <ansys.sam.sysml2.tools.ansys_sysml2_project.AnsysSysML2Project>` / :class:`AnsysScriptingProject <ansys.sam.sysml2.tools.ansys_scripting_project.AnsysScriptingProject>` class
 offers these advantages:
 

--- a/doc/source/user_guide/api/approaches.rst
+++ b/doc/source/user_guide/api/approaches.rst
@@ -121,7 +121,7 @@ You can find other examples of read/write instructions in :ref:`Read your Model 
             Use a connector
 
         .. grid-item-card:: Next step :fa:`arrow-right`
-            :link: load-model
+            :link: manage-projects
             :link-type: doc
 
-            Load a model
+            Manage projects

--- a/doc/source/user_guide/api/load-model.rst
+++ b/doc/source/user_guide/api/load-model.rst
@@ -41,15 +41,44 @@ Both of the approaches give you a Python version of your model.
 
 See :ref:`Approaches dynamic and static <Approaches_Section>` for more information about the differences between these approaches and when to use each of them.
 
+Create and load a new project
+=============================
+
+You can also create a new project on the server and load it in a single step. The project manager
+provides ``create_scripting_project()`` and ``create_sysml_project()`` methods that create the
+project remotely and return a fully built Python object.
+
+.. tab-set::
+
+    .. tab-item:: Dynamic approach
+
+        .. code:: python
+
+            project = project_manager.create_scripting_project(
+                name="My New Project",
+                description="A project created via PySAM SysML2",
+            )
+
+    .. tab-item:: Static approach
+
+        .. code:: python
+
+            project = project_manager.create_sysml_project(
+                name="My New Project",
+                description="A project created via PySAM SysML2",
+            )
+
+For more project management operations (update, delete, list), see :ref:`Manage projects <Manage_Projects_Section>`.
+
 .. only:: html
 
     .. grid:: 2
 
         .. grid-item-card:: :fa:`arrow-left` Previous step
-            :link: approaches
+            :link: manage-projects
             :link-type: doc
 
-            Dynamic vs static approaches
+            Manage projects
 
         .. grid-item-card:: Next step :fa:`arrow-right`
             :link: read-model

--- a/doc/source/user_guide/api/manage-projects.rst
+++ b/doc/source/user_guide/api/manage-projects.rst
@@ -1,0 +1,98 @@
+.. _Manage_Projects_Section:
+
+Manage projects
+###############
+
+The :class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>`
+class provides methods for managing projects on the server: listing, creating, updating, and
+deleting them.
+
+To use these methods, you need an instance of the
+:class:`SysML2ProjectManager <ansys.sam.sysml2.builder.sysml2_project_manager.SysML2ProjectManager>`
+(see :ref:`Use a connector <Create_C_Section>`).
+
+List projects
+=============
+
+Retrieve all projects accessible to the connected user:
+
+.. code:: python
+
+    projects = project_manager.get_projects()
+    for p in projects:
+        print(f"{p['name']} (id: {p['@id']})")
+
+Create a project
+================
+
+Create a new project on the server. The project is automatically built and returned as a
+Python object, ready to use.
+
+Two methods are available depending on the approach:
+
+.. tab-set::
+
+    .. tab-item:: Dynamic approach
+
+        .. code:: python
+
+            project = project_manager.create_scripting_project(
+                name="My New Project",
+                description="A project created via PySAM SysML2",
+            )
+
+    .. tab-item:: Static approach
+
+        .. code:: python
+
+            project = project_manager.create_sysml_project(
+                name="My New Project",
+                description="A project created via PySAM SysML2",
+            )
+
+Both methods create the project on the server and return a fully loaded project object, similar
+to calling ``get_scripting_project()`` or ``get_sysml_project()`` on an existing project.
+
+Update a project
+================
+
+Rename a project or change its description:
+
+.. code:: python
+
+    updated = project_manager.update_project(
+        project_id="<Project ID>",
+        name="My Renamed Project",
+        description="Updated description",
+    )
+
+Both ``name`` and ``description`` parameters are optional. Only the provided fields are updated.
+
+Delete a project
+================
+
+Delete a project from the server:
+
+.. code:: python
+
+    deleted = project_manager.delete_project(project_id="<Project ID>")
+
+.. warning::
+
+    Deleting a project is irreversible. All data associated with the project is permanently removed.
+
+.. only:: html
+
+    .. grid:: 2
+
+        .. grid-item-card:: :fa:`arrow-left` Previous step
+            :link: approaches
+            :link-type: doc
+
+            Dynamic vs static approaches
+
+        .. grid-item-card:: Next step :fa:`arrow-right`
+            :link: load-model
+            :link-type: doc
+
+            Load a model

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -25,11 +25,21 @@ required information.
 
     .. grid:: 2
 
+        .. grid-item-card:: Manage projects :fa:`folder-open`
+            :link: api/manage-projects
+            :link-type: doc
+
+            Explains how to create, update, and delete projects on the server.
+
         .. grid-item-card:: Load a model :fa:`cloud-download`
             :link: api/load-model
             :link-type: doc
 
             Explains how to load a model from the SysML V2 server.
+
+.. only:: html
+
+    .. grid:: 2
 
         .. grid-item-card:: Read your model :fa:`book`
             :link: api/read-model
@@ -37,25 +47,21 @@ required information.
 
             Explains how to read and parse your model.
 
-.. only:: html
-
-    .. grid:: 2
-
         .. grid-item-card:: Write data to your model :fa:`pencil`
             :link: api/write-model
             :link-type: doc
 
             Explains how to write and publish in your model.
 
+.. only:: html
+
+    .. grid:: 2
+
         .. grid-item-card:: Work with diagrams :fa:`project-diagram`
             :link: api/diagram-model
             :link-type: doc
 
             Explains how to download and explore diagrams.
-
-.. only:: html
-
-    .. grid:: 2
 
         .. grid-item-card:: Find required information :fa:`info-circle`
             :link: api/information
@@ -69,6 +75,7 @@ required information.
 
    api/create-conn
    api/approaches
+   api/manage-projects
    api/load-model
    api/read-model
    api/write-model

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -16,6 +16,7 @@ isort
 IN
 INOUT
 INPUT
+kwargs
 Makefile
 metaclass
 metamodel


### PR DESCRIPTION
Rename "Download diagrams and create new elements" to "Download diagrams
and navigate elements" since the example does not create elements.

Add project management (CRUD) documentation: new user guide page, new
example page, and extend load-model with create_project methods.