### PR TITLE
build: adopt prek as the local pre-commit replacement

### DIFF
--- a/doc/changelog.d/166.dependencies.md
+++ b/doc/changelog.d/166.dependencies.md
@@ -1,0 +1,1 @@
+Adopt prek as the local pre-commit replacement

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -171,23 +171,38 @@ Pre-commit hooks
 ^^^^^^^^^^^^^^^^
 
 PySAM SysML2 uses pre-commit hooks to automatically check code quality before each commit.
-Pre-commit runs various checks including code formatting, linting, and style validation.
+The hooks cover code formatting, linting, and style validation, and are declared in the
+``.pre-commit-config.yaml`` file at the repository root.
 
-To install the pre-commit hooks:
-
-.. code::
-
-    pre-commit install
-
-Once installed, the hooks run automatically when you run the ``git commit`` command. The pre-commit configuration is defined in the ``.pre-commit-config.yaml`` file.
-
-To manually run all pre-commit hooks on all files:
+For local development, PySAM SysML2 recommends `prek <https://prek.j178.dev/>`_, a faster
+drop-in alternative to `pre-commit <https://pre-commit.com/>`_ that reads the same
+``.pre-commit-config.yaml`` file. The ``prek`` package is already declared in the
+``checks`` optional dependency group, so a ``pip install -e ".[checks]"`` installs it.
+Otherwise, install it directly with:
 
 .. code::
 
-    pre-commit run --all-files
+    pip install prek
 
-If a hook fails, fix the reported issues and commit again. Some hooks (like ``ruff``) can automatically fix issues.
+To install the git hook so the checks run automatically on every ``git commit``:
+
+.. code::
+
+    prek install
+
+.. note::
+   If you previously ran ``pre-commit install`` in this repository, run
+   ``prek install -f`` once to replace the existing git hook shim.
+
+To manually run all hooks on every file in the repository:
+
+.. code::
+
+    prek run --all-files
+
+If a hook fails, fix the reported issues and commit again. Some hooks (like ``ruff``)
+automatically fix issues. The CI/CD pipeline enforces the exact same hooks, so passing
+locally with ``prek`` matches the result you will get on GitHub.
 
 
 Quality checks workflow
@@ -200,7 +215,7 @@ Before submitting a pull request, ensure all quality checks pass:
 3. **Check code style**: ``ruff check .``
 4. **Format code**: ``ruff format .``
 5. **Check documentation style**: ``cd doc; vale sync; vale .``
-6. **Run pre-commit checks**: ``pre-commit run --all-files``
+6. **Run pre-commit checks**: ``prek run --all-files``
 
 The CI/CD pipeline automatically run these checks on multiple Python versions (3.10, 3.11, 3.12, 3.13, and 3.14) when you submit your pull request.
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -202,7 +202,7 @@ To manually run all hooks on every file in the repository:
 
 If a hook fails, fix the reported issues and commit again. Some hooks (like ``ruff``)
 automatically fix issues. The CI/CD pipeline enforces the exact same hooks, so passing
-locally with ``prek`` matches the result you will get on GitHub.
+locally with ``prek`` matches the result on GitHub.
 
 
 Quality checks workflow

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -32,6 +32,7 @@ OUT
 parse_and_set_value
 PAT
 Personal Access Token
+prek
 py
 PySAM
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ tests = [
     "pytest-cov==7.1.0",
     "pytest-mock==3.15.1",
 ]
-checks = ["pre-commit==4.6.0"]
+checks = ["prek==0.3.2"]
 
 [project.urls]
 Source = "https://github.com/ansys/pysam-sysml2"


### PR DESCRIPTION
Switch local contributor tooling from `pre-commit` to `prek`
(https://prek.j178.dev/), aligning with the Ansys-wide migration.

Changes:
- pyproject.toml: `checks` extra now pins `prek==0.3.2` instead of
  `pre-commit==4.6.0`.
- doc/source/contributing.rst: the Pre-commit hooks section and the
  Quality checks workflow checklist now document `prek install` and
  `prek run --all-files`. A note is added about running `prek install -f`
  to replace any existing pre-commit git shim.
- doc/styles/config/vocabularies/ANSYS/accept.txt: add `prek` so Vale
  does not flag it.
  
Issue #165