### PR TITLE
refactor: use a dot-safe ClassName_<id> fallback for empty-name elements

### DIFF
--- a/doc/changelog.d/187.miscellaneous.md
+++ b/doc/changelog.d/187.miscellaneous.md
@@ -1,1 +1,1 @@
-Use <classname> <id> for elements with empty names
+Use a dot-safe ClassName_<id> fallback for empty-name elements

--- a/doc/changelog.d/187.miscellaneous.md
+++ b/doc/changelog.d/187.miscellaneous.md
@@ -1,0 +1,1 @@
+Use <classname> <id> for elements with empty names

--- a/src/ansys/sam/sysml2/builder/classes/sysml_util.py
+++ b/src/ansys/sam/sysml2/builder/classes/sysml_util.py
@@ -33,11 +33,12 @@ class SysMLUtil:
 
     @staticmethod
     def check_inherited_name(element: SysMLElement) -> str:
-        """Resolve the element name with a ``ClassName::id`` fallback when null or empty."""
+        """Resolve the element name with a dot-safe ``ClassName_<id>`` fallback when null or empty."""
         name = getattr(element, "_name", None)
         if name:
             return name
-        return element.__class__.__name__.split(".")[-1] + "::" + element._id
+        class_name = element.__class__.__name__.split(".")[-1]
+        return f"{class_name}_{element._id}".replace("-", "_")
 
     @staticmethod
     def check_sysml_inherited_name(element: Element) -> str:

--- a/src/ansys/sam/sysml2/builder/classes/sysml_util.py
+++ b/src/ansys/sam/sysml2/builder/classes/sysml_util.py
@@ -33,33 +33,19 @@ class SysMLUtil:
 
     @staticmethod
     def check_inherited_name(element: SysMLElement) -> str:
-        """Check and return the name of the element."""
-        if isinstance(element, str):
-            return "::" + element
-        if hasattr(element, "_name"):
-            return getattr(element, "_name")
-        elif hasattr(element, "_redefinedFeature"):
-            redefined_feature = getattr(element, "_redefinedFeature", [])
-            if isinstance(redefined_feature, list) and len(redefined_feature) > 0:
-                redefined_feature = redefined_feature[0]
-            return SysMLUtil.check_inherited_name(redefined_feature)
-        else:
-            return element.__class__.__name__.split(".")[-1] + "::" + element._id
+        """Resolve the element name with a ``ClassName::id`` fallback when null."""
+        name = getattr(element, "_name", None)
+        if name is not None:
+            return name
+        return element.__class__.__name__.split(".")[-1] + "::" + element._id
 
     @staticmethod
     def check_sysml_inherited_name(element: Element) -> str:
-        """Check and return the name of the element."""
-        if isinstance(element, str):
-            return "::" + element
-        if hasattr(element, "name"):
-            return getattr(element, "name")
-        elif hasattr(element, "redefined_feature"):
-            redefined_feature = getattr(element, "redefined_feature", [])
-            if isinstance(redefined_feature, list) and len(redefined_feature) > 0:
-                redefined_feature = redefined_feature[0]
-            return SysMLUtil.check_sysml_inherited_name(redefined_feature)
-        else:
-            return element.__class__.__name__.split(".")[-1] + "::" + element.id
+        """Resolve the element name with a ``ClassName::id`` fallback when null."""
+        name = getattr(element, "name", None)
+        if name is not None:
+            return name
+        return element.__class__.__name__.split(".")[-1] + "::" + element.id
 
     @staticmethod
     def get_sysml_constructor(element_type: str) -> type[EObject]:

--- a/src/ansys/sam/sysml2/builder/classes/sysml_util.py
+++ b/src/ansys/sam/sysml2/builder/classes/sysml_util.py
@@ -33,7 +33,7 @@ class SysMLUtil:
 
     @staticmethod
     def check_inherited_name(element: SysMLElement) -> str:
-        """Resolve the element name with a dot-safe ``ClassName_<id>`` fallback when null or empty."""
+        """Resolve the name with a dot-safe ``ClassName_<id>`` fallback when empty."""
         name = getattr(element, "_name", None)
         if name:
             return name

--- a/src/ansys/sam/sysml2/builder/classes/sysml_util.py
+++ b/src/ansys/sam/sysml2/builder/classes/sysml_util.py
@@ -33,17 +33,17 @@ class SysMLUtil:
 
     @staticmethod
     def check_inherited_name(element: SysMLElement) -> str:
-        """Resolve the element name with a ``ClassName::id`` fallback when null."""
+        """Resolve the element name with a ``ClassName::id`` fallback when null or empty."""
         name = getattr(element, "_name", None)
-        if name is not None:
+        if name:
             return name
         return element.__class__.__name__.split(".")[-1] + "::" + element._id
 
     @staticmethod
     def check_sysml_inherited_name(element: Element) -> str:
-        """Resolve the element name with a ``ClassName::id`` fallback when null."""
+        """Resolve the element name with a ``ClassName::id`` fallback when null or empty."""
         name = getattr(element, "name", None)
-        if name is not None:
+        if name:
             return name
         return element.__class__.__name__.split(".")[-1] + "::" + element.id
 

--- a/tests/unit/sam/sysml2/builder/test_sysml_util.py
+++ b/tests/unit/sam/sysml2/builder/test_sysml_util.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for SysMLUtil name resolution."""
+
+from ansys.sam.sysml2.builder.classes.sysml_util import SysMLUtil
+from ansys.sam.sysml2.classes.sysml_element import SysMLElement
+
+
+class TestCheckInheritedName:
+    """Scripting fallback names must be dot-safe Python identifiers."""
+
+    def test_returns_real_name_when_present(self):
+        element = SysMLElement("53f1d978-9696-4c68-bb93-4d38571fa4a5")
+        object.__setattr__(element, "_name", "MyPart")
+
+        assert SysMLUtil.check_inherited_name(element) == "MyPart"
+
+    def test_fallback_replaces_colons_and_dashes_with_underscores(self):
+        part_def_cls = type("PartDefinition", (SysMLElement,), {})
+        element = part_def_cls("53f1d978-9696-4c68-bb93-4d38571fa4a5")
+
+        resolved = SysMLUtil.check_inherited_name(element)
+
+        assert resolved == "PartDefinition_53f1d978_9696_4c68_bb93_4d38571fa4a5"
+        assert "::" not in resolved
+        assert "-" not in resolved
+        assert resolved.isidentifier()


### PR DESCRIPTION
Elements like `ConnectionUsage` come back from the server with
`name = null`, which broke the inherited-name lookup. The legacy
`_redefinedFeature` fallback also no longer applies in the new
metamodel. This PR replaces both with a single fallback that fires
whenever the name is `null` (Python `None`).

Changes
-------

- `src/ansys/sam/sysml2/builder/classes/sysml_util.py`: drop the dead
  `_redefinedFeature` and `isinstance(str)` branches in
  `check_inherited_name` / `check_sysml_inherited_name`; fall back to a
  generated identifier when the name is `None`. The previous
  implementation checked `hasattr(element, "_name")` and returned the
  value even when it was `None`, which made the fallback unreachable;
  this PR switches to a `name is not None` check so the fallback
  actually fires.
- For the scripting flavour (`check_inherited_name`), the fallback is
  the dot-safe `ClassName_<id>`: `::` and `-` are replaced by `_` so the
  element stays reachable through Python attribute access
  (`root.ConnectionUsage_<id>`). The metamodel flavour
  (`check_sysml_inherited_name`) keeps the `ClassName::<id>` form, since
  it is navigated through `get()` and never via attribute access.

Tests
-----

- `tests/unit/sam/sysml2/builder/test_sysml_util.py`: assert a real name
  is returned unchanged and that the scripting fallback yields a valid
  Python identifier with no `::` or `-`.

Independent of PR 1 (regen), PR 2 (builder adapter), and PR 3
(FeatureValue payload). Only touches `sysml_util.py` and its test.

Issue #183.
