### PR TITLE
refactor: adapt builder to FeatureChaining with lazy inherited-proxy caching

### DIFF
--- a/doc/changelog.d/188.miscellaneous.md
+++ b/doc/changelog.d/188.miscellaneous.md
@@ -1,0 +1,1 @@
+Adapt builder to FeatureChaining with lazy inherited-proxy caching

--- a/src/ansys/sam/sysml2/builder/mapper/sysml_mapper.py
+++ b/src/ansys/sam/sysml2/builder/mapper/sysml_mapper.py
@@ -112,9 +112,6 @@ class SysMLMapper(Mapper):
         from ansys.sam.sysml2.tools.name_utils import NameUtils
 
         field_name = "_" + NameUtils.to_snake_case(field_name)
-        # Fix due to differences between Standard API and Metamodel
-        if field_name == "_inherited_feature":
-            field_name = "_owned_inherited_feature"
         if isinstance(field_values, list):
             return self._add_list_to_field(element, field_name, field_values)
         if isinstance(field_values, dict):

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -43,7 +43,7 @@ from ansys.sam.sysml2.meta_model.element import Element
 from ansys.sam.sysml2.observer.observer import ModificationObserver
 
 _SCRIPTING_KEEP = {"get_value", "parse_and_set_value", "set_value", "delete"}
-sysml_element_dir = dir(SysMLElement) + ["_id"]
+_SYSML_KEEP = {"get", "get_value", "parse_and_set_value", "set_value", "delete"}
 
 
 class SysML2ProjectBuilder:
@@ -104,11 +104,7 @@ class SysML2ProjectBuilder:
         self.extract_root_and_check_names(project)
 
     def extract_root_and_check_names(self, project: Project | ScriptingProject):
-        """Extract root elements and resolve inherited names in a single pass.
-
-        Both operations are combined into one iteration over the project
-        environment to avoid looping twice.
-        """
+        """Extract root elements and resolve inherited names in a single pass."""
         roots = []
         if isinstance(project, Project):
             for element in project._env.values():
@@ -210,7 +206,7 @@ class SysML2ProjectBuilder:
             else:
                 missing.add(element_id)
         project._unresolved_fields = [f for f in unresolved_fields if f not in resolved_fields]
-        return {x for x in missing if "/?" not in x}
+        return missing
 
     def _get_missing(
         self, project: Project | ScriptingProject, missing_elements: set[str]
@@ -243,261 +239,37 @@ class SysML2ProjectBuilder:
         return self._connector.execute_query(project._id, query.to_json())
 
     def _resolve_inherited_link(self, project: Project | ScriptingProject):
-        """Resolve all inherited elements and add them as members."""
+        """Refresh the per-element hash map; scripting also eagerly wraps inherited children."""
         if isinstance(project, ScriptingProject):
             for element in project._env.copy().values():
-                self.clear_element(_SCRIPTING_KEEP, element)
-                self.update_element(element)
-
-            self._resolve_dynamic_inherited_fields(project)
-
+                self._clear_element(element, _SCRIPTING_KEEP)
+                all_element = self.__get_all_element(element)
+                element._element_hash_map = all_element
+                for name, e in all_element.items():
+                    if name is not None:
+                        setattr(element, f"#{name}", e)
         else:
             for element in project._env.copy().values():
+                self._clear_element(element, _SYSML_KEEP)
                 element._element_hash_map = self.__get_all_sysml_element(element)
-            self._resolve_sysml_inherited_fields(project)
 
-    def _resolve_dynamic_inherited_fields(self, project: ScriptingProjectImpl):
-        """Resolve all inherited fields and add them as members."""
-        composed_ids = {
-            x.get_id() for x in project._unresolved_fields if x.get_id().startswith("/?")
-        }
-        elements = {}
-        for composed_id in composed_ids:
-            elements_ids = composed_id.split("/?")
-            element: SysMLElement = project._env.get(elements_ids[-1], None)
-            if element is None:
-                continue
-            parents = self._get_all_parents(project, elements_ids)
-            if not parents:
-                continue
-            elif len(parents) == 1:
-                elements.update(self._resolve_single_level_inherited_dynamic(element, parents))
-            else:
-                elements.update(self._resolve_multi_level_inherited_dynamic(element, parents))
-        project._env.update(elements)
-        self._resolve_fields(project)
-
-    def _resolve_sysml_inherited_fields(self, project: Project):
-        """Resolve all inherited fields and add them as members."""
-        composed_ids = {
-            x.get_id() for x in project._unresolved_fields if x.get_id().startswith("/?")
-        }
-        elements = {}
-        for composed_id in composed_ids:
-            elements_ids = composed_id.split("/?")
-            element: Element = project._env.get(elements_ids[-1], None)
-            if element is None:
-                continue
-            parents = self._get_all_parents(project, elements_ids)
-            if not parents:
-                continue
-            elif len(parents) == 1:
-                elements.update(self._resolve_single_level_inherited(element, parents))
-            else:
-                elements.update(self._resolve_multi_level_inherited(element, parents))
-        project._env.update(elements)
-        self._resolve_fields(project)
-
-    def _resolve_multi_level_inherited_dynamic(self, element, parents):
-        """
-        Resolve multi-level inherited element.
-
-        Parameters
-        ----------
-        element :  SysMLElement
-            The element to resolve.
-        parents : list[Element]
-            The list of parent elements.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the resolved inherited element.
-        """
-        current = parents[0]
-        for parent in parents[1:]:
-            if parent._name is not None and parent._name in current._element_hash_map:
-                current = getattr(current, parent._name, None)
-            else:
-                return {}
-        if element._name is not None and element._name in current._element_hash_map:
-            element_ = getattr(current, element._name, None)
-        else:
-            return {}
-        if element_ is not None:
-            return {element_._id: element_}
-        return {}
-
-    def _resolve_single_level_inherited_dynamic(self, element, parents):
-        """
-        Resolve single-level inherited element.
-
-        Parameters
-        ----------
-        element : SysMLElement
-            The element to resolve.
-        parents : list[Element]
-            The list of parent elements.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the resolved inherited element.
-        """
-        if element._name is not None:
-            e = getattr(parents[0], element._name, None)
-            if e is not None:
-                return {e._id: e}
-            return {}
-        else:
-            from ansys.sam.sysml2.classes.sysml_inherited_element import (
-                SysMLInheritedElement,
-            )
-
-            element_ = SysMLInheritedElement(
-                parents[0],
-                next(
-                    (e for e in parents[0]._element_hash_map if e._id == element._id),
-                    None,
-                ),
-            )
-            if element_._element is not None:
-                return {element_._id: element_}
-        return {}
-
-    def _resolve_multi_level_inherited(self, element, parents):
-        """
-        Resolve multi-level inherited element.
-
-        Parameters
-        ----------
-        element : Element
-            The element to resolve.
-        parents : list[Element]
-            The list of parent elements.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the resolved inherited element.
-        """
-        current = parents[0]
-        for parent in parents[1:]:
-            if parent.name is not None and parent.name in current._element_hash_map:
-                current = current.get(parent.name)
-            else:
-                return {}
-        if element.name is not None and element.name in current._element_hash_map:
-            element_ = current.get(element.name)
-        else:
-            return {}
-        if element_ is not None:
-            return {element_.id: element_}
-        return {}
-
-    def _resolve_single_level_inherited(self, element, parents):
-        """
-        Resolve single-level inherited element.
-
-        Parameters
-        ----------
-        element : Element
-            The element to resolve.
-        parents : list[Element]
-            The list of parent elements.
-
-        Returns
-        -------
-        dict
-            A dictionary containing the resolved inherited element.
-        """
-        if element.name is not None:
-            e = parents[0].get(element.name)
-            if e is not None:
-                return {e.id: e}
-            return {}
-        else:
-            from ansys.sam.sysml2.classes.sysml_inherited_element import (
-                SysMLInheritedElement,
-            )
-
-            element_ = SysMLInheritedElement(
-                parents[0],
-                next(
-                    (e for e in parents[0]._element_hash_map if e.id == element.id),
-                    None,
-                ),
-            )
-            if element_._element is not None:
-                return {element_.id: element_}
-        return {}
-
-    def _get_all_parents(self, project, elements_ids):
-        """
-        Get all parent elements from the composed ID.
-
-        Parameters
-        ----------
-        project : Project | ScriptingProject
-            The project containing the elements.
-        elements_ids : list[str]
-            The list of element IDs.
-
-        Returns
-        -------
-        list[Element]
-            The list of parent elements.
-        """
-        parents: list[Element] = []
-        for parent_id in elements_ids[1:-1]:
-            parent_element = project._env.get(parent_id, None)
-            if parent_element is None:
-                break
-            parents.append(parent_element)
-        return parents
-
-    def update_element(self, element):
-        """
-        Update the element with inherited elements.
-
-        Parameters
-        ----------
-        element : SysMLElement
-            The element to update.
-        """
-        all_element = self.__get_all_element(element)
-        element._element_hash_map = all_element
-        for name, e in all_element.items():
-            if name is not None:
-                setattr(element, f"#{name}", e)
-
-    def clear_element(self, ignore_list, element):
-        """
-        Clear all inherited elements in the element.
-
-        Parameters
-        ----------
-        ignore_list : list
-            List of attributes to ignore when clearing.
-        element : SysMLElement
-            The element to clear.
-        """
-        [
-            delattr(element, x)
-            for x in list(element.__dict__.keys())
-            if not x.startswith("_") and x not in ignore_list
-        ]
+    @staticmethod
+    def _clear_element(element, keep: set[str]) -> None:
+        """Drop stale pre-wrapped proxies from a previous build before refilling."""
+        for x in list(element.__dict__.keys()):
+            if not x.startswith("_") and x not in keep:
+                delattr(element, x)
 
     def __get_all_element(self, element: SysMLElement) -> dict:
-        """Parse all definitions from the element and return its owned elements."""
+        """Return owned + inherited children of a scripting element keyed by ``_name``."""
         all_element = getattr(element, "_ownedElement", []).copy()
         all_element.extend(getattr(element, "_inheritedFeature", []))
         return {x._name: x for x in all_element if isinstance(x, SysMLElement)}
 
     def __get_all_sysml_element(self, element: Element) -> dict:
-        """Parse all definitions and collect owned elements."""
+        """Return owned + inherited children of a metamodel element keyed by ``name``."""
         all_element = element.owned_element.copy()
-        all_element.extend(getattr(element, "owned_inherited_feature", []).copy())
+        all_element.extend(getattr(element, "inherited_feature", []).copy())
         return {x.name: x for x in all_element if isinstance(x, Element)}
 
     def _add_write_access(self, project: Project | ScriptingProject):

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -239,19 +239,17 @@ class SysML2ProjectBuilder:
         return self._connector.execute_query(project._id, query.to_json())
 
     def _resolve_inherited_link(self, project: Project | ScriptingProject):
-        """Refresh the per-element hash map; scripting also eagerly wraps inherited children."""
+        """Refresh per-element hash map and owned-name set; proxies are created lazily on access."""
         if isinstance(project, ScriptingProject):
             for element in project._env.copy().values():
                 self._clear_element(element, _SCRIPTING_KEEP)
-                all_element = self.__get_all_element(element)
-                element._element_hash_map = all_element
-                for name, e in all_element.items():
-                    if name is not None:
-                        setattr(element, f"#{name}", e)
+                element._element_hash_map = self.__get_all_element(element)
+                element._owned_names = self.__get_owned_names(element)
         else:
             for element in project._env.copy().values():
                 self._clear_element(element, _SYSML_KEEP)
                 element._element_hash_map = self.__get_all_sysml_element(element)
+                element._owned_names = self.__get_sysml_owned_names(element)
 
     @staticmethod
     def _clear_element(element, keep: set[str]) -> None:
@@ -266,11 +264,23 @@ class SysML2ProjectBuilder:
         all_element.extend(getattr(element, "_inheritedFeature", []))
         return {x._name: x for x in all_element if isinstance(x, SysMLElement)}
 
+    def __get_owned_names(self, element: SysMLElement) -> set[str]:
+        """Return the names of owned (non-inherited) children of a scripting element."""
+        return {
+            x._name
+            for x in getattr(element, "_ownedElement", [])
+            if isinstance(x, SysMLElement) and x._name is not None
+        }
+
     def __get_all_sysml_element(self, element: Element) -> dict:
         """Return owned + inherited children of a metamodel element keyed by ``name``."""
         all_element = element.owned_element.copy()
         all_element.extend(getattr(element, "inherited_feature", []).copy())
         return {x.name: x for x in all_element if isinstance(x, Element)}
+
+    def __get_sysml_owned_names(self, element: Element) -> set[str]:
+        """Return the names of owned (non-inherited) children of a metamodel element."""
+        return {x.name for x in element.owned_element if isinstance(x, Element) and x.name is not None}
 
     def _add_write_access(self, project: Project | ScriptingProject):
         """Add write rules access on the project."""

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -278,7 +278,9 @@ class SysML2ProjectBuilder:
 
     def __get_sysml_owned_names(self, element: Element) -> set[str]:
         """Return the names of owned (non-inherited) children of a metamodel element."""
-        return {x.name for x in element.owned_element if isinstance(x, Element) and x.name is not None}
+        return {
+            x.name for x in element.owned_element if isinstance(x, Element) and x.name is not None
+        }
 
     def _add_write_access(self, project: Project | ScriptingProject):
         """Add write rules access on the project."""

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -249,8 +249,7 @@ class SysML2ProjectBuilder:
                 element._element_hash_map = self.__get_all_sysml_element(element)
                 element._owned_names = self.__get_sysml_owned_names(element)
 
-    @staticmethod
-    def _clear_element(element, keep: set[str]) -> None:
+    def _clear_element(self, element, keep: set[str]) -> None:
         """Drop stale pre-wrapped proxies from a previous build before refilling."""
         for x in list(element.__dict__.keys()):
             if not x.startswith("_") and x not in keep:

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -108,16 +108,14 @@ class SysML2ProjectBuilder:
         roots = []
         if isinstance(project, Project):
             for element in project._env.values():
-                setattr(
-                    element,
-                    "declared_name",
-                    SysMLUtil.check_sysml_inherited_name(element),
-                )
+                element.declared_name = SysMLUtil.check_sysml_inherited_name(element)
                 if self._is_logical_root(element, "owner"):
                     roots.append(element)
         elif isinstance(project, ScriptingProject):
             for element in project._env.values():
-                setattr(element, "_name", SysMLUtil.check_inherited_name(element))
+                resolved = SysMLUtil.check_inherited_name(element)
+                element._name = resolved
+                element._declaredName = resolved
                 if self._is_logical_root(element, "_owner"):
                     roots.append(element)
         else:

--- a/src/ansys/sam/sysml2/classes/inherited_element.py
+++ b/src/ansys/sam/sysml2/classes/inherited_element.py
@@ -54,7 +54,7 @@ def build_composed_name(owner, element, is_inherited):
 
 
 class InheritedElement(SysMLElement):
-    """A proxy class for the element that is not created yet."""
+    """Proxy that exposes an inherited element under its on-the-fly owner."""
 
     def __init__(self, owner, element):
         """Construct a new instance."""
@@ -63,6 +63,13 @@ class InheritedElement(SysMLElement):
         self._element = element
         self._id = build_composed_name(owner, element, True)
         self._owner = owner
+
+    def __setattr__(self, name, value):
+        """Store proxy plumbing directly; route model writes through the parent observer."""
+        if name in ("_observer", "_element", "_id", "_owner"):
+            object.__setattr__(self, name, value)
+            return
+        super().__setattr__(name, value)
 
     def __dir__(self):
         """Get the attribute list from the real element."""

--- a/src/ansys/sam/sysml2/classes/project.py
+++ b/src/ansys/sam/sysml2/classes/project.py
@@ -33,6 +33,11 @@ class Project(ABC):
     """Provides the project interface for users."""
 
     @property
+    def id(self) -> str:
+        """Get the project ID."""
+        return self.get_id()
+
+    @property
     def name(self) -> str:
         """Get the project name."""
         return self.get_name()

--- a/src/ansys/sam/sysml2/classes/scripting_project.py
+++ b/src/ansys/sam/sysml2/classes/scripting_project.py
@@ -32,6 +32,11 @@ class ScriptingProject(ABC):
     """Scripting project interface for users."""
 
     @property
+    def id(self) -> str:
+        """Get the project ID."""
+        return self.get_id()
+
+    @property
     def name(self) -> str:
         """Get the project name."""
         return self.get_name()

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -46,8 +46,8 @@ class SysMLElement:
         self._id = element_id
 
     def __dir__(self):
-        """List owned + inherited child names (clean), excluding internal #cache keys."""
-        base = [b for b in super().__dir__() if not b.startswith("#")]
+        """List owned + inherited child names alongside normal attributes."""
+        base = list(super().__dir__())
         hmap = self.__dict__.get("_element_hash_map", {})
         children = [k for k in hmap if k is not None]
         names = set(list(base) + children)
@@ -65,17 +65,13 @@ class SysMLElement:
         return self._resolve_child(name, hmap)
 
     def _resolve_child(self, name, hmap):
-        """Return the owned child raw, or an ``InheritedElement`` proxy cached under ``#name``."""
+        """Return the owned child raw, or an ``InheritedElement`` proxy, cached under the child name."""
         from ansys.sam.sysml2.classes.inherited_element import InheritedElement
 
-        cache_key = f"#{name}"
-        cached = self.__dict__.get(cache_key)
-        if cached is not None:
-            return cached
         child = hmap[name]
         is_owned = name in self.__dict__.get("_owned_names", set())
         result = child if is_owned else InheritedElement(self, child)
-        self.__dict__[cache_key] = result
+        self.__dict__[name] = result
         return result
 
     def __setattr__(self, name: str, value: object):

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -46,8 +46,8 @@ class SysMLElement:
         self._id = element_id
 
     def __dir__(self):
-        """Get the attribute list from the real element."""
-        base = super().__dir__()
+        """List owned + inherited child names (clean), excluding internal #cache keys."""
+        base = [b for b in super().__dir__() if not b.startswith("#")]
         hmap = self.__dict__.get("_element_hash_map", {})
         children = [k for k in hmap if k is not None]
         names = set(list(base) + children)

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -56,49 +56,33 @@ class SysMLElement:
         return sorted(names)
 
     def __getattr__(self, name):
-        """Get the attribute from the real element."""
-        from ansys.sam.sysml2.classes.inherited_element import InheritedElement
-
+        """Resolve hash-map children lazily; only fires when normal attribute lookup fails."""
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
-
         hmap = self.__dict__.get("_element_hash_map", {})
-        if name in hmap:
-            child = hmap[name]
-            owned = self.__dict__.get("_ownedElement", [])
-            is_owned = any(
-                getattr(x, "_name", None) == name for x in owned if isinstance(x, SysMLElement)
-            )
-            if is_owned:
-                return child
-            return InheritedElement(self, child)
+        if name not in hmap:
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+        return self._resolve_child(name, hmap)
 
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
-
-    def __setattr__(self, name: str, value: object):
-        """
-        Intercept attribute assignment and notify the modification observer.
-
-        Parameters
-        ----------
-        name : str
-            Name of the key.
-        value : object
-            Value of the key.
-        """
+    def _resolve_child(self, name, hmap):
+        """Return the owned child raw, or an ``InheritedElement`` proxy cached under ``#name``."""
         from ansys.sam.sysml2.classes.inherited_element import InheritedElement
 
+        cache_key = f"#{name}"
+        cached = self.__dict__.get(cache_key)
+        if cached is not None:
+            return cached
+        child = hmap[name]
+        is_owned = name in self.__dict__.get("_owned_names", set())
+        result = child if is_owned else InheritedElement(self, child)
+        self.__dict__[cache_key] = result
+        return result
+
+    def __setattr__(self, name: str, value: object):
+        """Intercept attribute assignment and notify the modification observer."""
         if name != "_observer" and getattr(self, "_observer", None) is not None:
             self._observer.notify(self._id, name, value)
-        if name.startswith("#"):
-            name = name[1:]
-            if any(name == getattr(x, "_name", None) for x in getattr(self, "_ownedElement", [])):
-                super().__setattr__(name, value)
-            else:
-                super().__setattr__(name, InheritedElement(self, value))
-
-        else:
-            super().__setattr__(name, value)
+        super().__setattr__(name, value)
 
     def get_value(self):
         """Get the value of the feature."""

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -65,7 +65,7 @@ class SysMLElement:
         return self._resolve_child(name, hmap)
 
     def _resolve_child(self, name, hmap):
-        """Return the owned child raw, or an ``InheritedElement`` proxy, cached under the child name."""
+        """Return the owned child, or an ``InheritedElement`` proxy, cached under its name."""
         from ansys.sam.sysml2.classes.inherited_element import InheritedElement
 
         child = hmap[name]

--- a/src/ansys/sam/sysml2/classes/sysml_inherited_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_inherited_element.py
@@ -69,6 +69,10 @@ class SysMLInheritedElement(EObject):
         """Get the attribute list from the real element."""
         return dir(self._element)
 
+    def get_value(self):
+        """Read the value from the wrapped feature (the proxy itself is not a Feature)."""
+        return self._element.get_value()
+
     def __getattr__(self, name):
         """Get the attribute from the real element."""
         if name in ("_observer", "_element", "id", "owner"):

--- a/src/ansys/sam/sysml2/classes/sysml_inherited_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_inherited_element.py
@@ -45,8 +45,7 @@ def build_composed_name(owner, element, is_inherited):
     is_contained_in_inherited_element = isinstance(owner, SysMLInheritedElement)
     if is_inherited:
         is_inherited = (
-            element in getattr(owner, "owned_inherited_feature", [])
-            or is_contained_in_inherited_element
+            element in getattr(owner, "inherited_feature", []) or is_contained_in_inherited_element
         )
         if is_contained_in_inherited_element:
             return f"{owner.id}/?{element.identifier}"
@@ -55,7 +54,7 @@ def build_composed_name(owner, element, is_inherited):
 
 
 class SysMLInheritedElement(EObject):
-    """A proxy class for the element that is not created yet."""
+    """Proxy that exposes an inherited element under its on-the-fly owner."""
 
     def __init__(self, owner, element):
         """Construct a new instance."""

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -45,42 +45,45 @@ class EObject:
         self._element_hash_map = {}
 
     def __dir__(self):
-        """Children are reachable via get(), not dot; hide the internal proxy cache."""
+        """Expose owned + inherited names for Jupyter ``<TAB>`` autocompletion."""
         names = [a for a in super().__dir__() if a != "_proxy_cache" and not a.startswith("#")]
+        hmap = self.__dict__.get("_element_hash_map", {})
+        children = [k for k in hmap if k is not None]
+        names = list(set(names + children))
         if not ValueHelper.is_value_capable(self):
             names = [a for a in names if a not in ("get_value", "set_value", "parse_and_set_value")]
         return sorted(names)
 
-    def get(self, element_name: str) -> "Element | None":  # noqa: F821
-        """
-        Find an owned element by its name.
-
-        Parameters
-        ----------
-        element_name : str
-            Element name
-
-        Returns
-        -------
-        Element
-            The Element or None if not found
-        """
-        from ansys.sam.sysml2.classes.sysml_inherited_element import (
-            SysMLInheritedElement,
-        )
-
+    def __getattr__(self, name):
+        """Lazy access for non-property child names; only fires when normal lookup fails."""
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
         hmap = self.__dict__.get("_element_hash_map", {})
-        if element_name in hmap:
-            child = hmap[element_name]
-            owned = self.__dict__.get("_owned_element", [])
-            is_owned = any(
-                getattr(x, "name", None) == element_name for x in owned if isinstance(x, EObject)
-            )
-            if is_owned:
-                return child
-            return SysMLInheritedElement(self, child)
+        if name in hmap:
+            return self._resolve_child(name, hmap)
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
-        return None
+    def _resolve_child(self, name, hmap):
+        """Return the owned child raw, or a ``SysMLInheritedElement`` proxy cached under ``#name``."""
+        from ansys.sam.sysml2.classes.sysml_inherited_element import SysMLInheritedElement
+
+        cache_key = f"#{name}"
+        cached = self.__dict__.get(cache_key)
+        if cached is not None:
+            return cached
+        child = hmap[name]
+        owned = self.__dict__.get("_owned_element", [])
+        is_owned = any(getattr(x, "name", None) == name for x in owned if isinstance(x, EObject))
+        result = child if is_owned else SysMLInheritedElement(self, child)
+        self.__dict__[cache_key] = result
+        return result
+
+    def get(self, element_name: str) -> "Element | None":  # noqa: F821
+        """Find an owned or inherited element by name; reuse the cached proxy when present."""
+        hmap = self.__dict__.get("_element_hash_map", {})
+        if element_name not in hmap:
+            return None
+        return self._resolve_child(element_name, hmap)
 
     @property
     def id(self):

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -72,8 +72,7 @@ class EObject:
         if cached is not None:
             return cached
         child = hmap[name]
-        owned = self.__dict__.get("_owned_element", [])
-        is_owned = any(getattr(x, "name", None) == name for x in owned if isinstance(x, EObject))
+        is_owned = name in self.__dict__.get("_owned_names", set())
         result = child if is_owned else SysMLInheritedElement(self, child)
         self.__dict__[cache_key] = result
         return result

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -52,7 +52,7 @@ class EObject:
         return sorted(names)
 
     def _resolve_child(self, name, hmap):
-        """Return the owned child raw, or a ``SysMLInheritedElement`` proxy, cached in a hidden dict."""
+        """Return the owned child, or a ``SysMLInheritedElement`` proxy, cached privately."""
         from ansys.sam.sysml2.classes.sysml_inherited_element import SysMLInheritedElement
 
         cache = self.__dict__.setdefault("_proxy_cache", {})

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -45,23 +45,11 @@ class EObject:
         self._element_hash_map = {}
 
     def __dir__(self):
-        """Expose owned + inherited names for Jupyter ``<TAB>`` autocompletion."""
+        """Children are reachable via get(), not dot; hide the internal proxy cache."""
         names = [a for a in super().__dir__() if a != "_proxy_cache" and not a.startswith("#")]
-        hmap = self.__dict__.get("_element_hash_map", {})
-        children = [k for k in hmap if k is not None]
-        names = list(set(names + children))
         if not ValueHelper.is_value_capable(self):
             names = [a for a in names if a not in ("get_value", "set_value", "parse_and_set_value")]
         return sorted(names)
-
-    def __getattr__(self, name):
-        """Lazy access for non-property child names; only fires when normal lookup fails."""
-        if name.startswith("__") and name.endswith("__"):
-            raise AttributeError(name)
-        hmap = self.__dict__.get("_element_hash_map", {})
-        if name in hmap:
-            return self._resolve_child(name, hmap)
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
     def _resolve_child(self, name, hmap):
         """Return the owned child raw, or a ``SysMLInheritedElement`` proxy cached under ``#name``."""

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -52,17 +52,16 @@ class EObject:
         return sorted(names)
 
     def _resolve_child(self, name, hmap):
-        """Return the owned child raw, or a ``SysMLInheritedElement`` proxy cached under ``#name``."""
+        """Return the owned child raw, or a ``SysMLInheritedElement`` proxy, cached in a hidden dict."""
         from ansys.sam.sysml2.classes.sysml_inherited_element import SysMLInheritedElement
 
-        cache_key = f"#{name}"
-        cached = self.__dict__.get(cache_key)
-        if cached is not None:
-            return cached
+        cache = self.__dict__.setdefault("_proxy_cache", {})
+        if name in cache:
+            return cache[name]
         child = hmap[name]
         is_owned = name in self.__dict__.get("_owned_names", set())
         result = child if is_owned else SysMLInheritedElement(self, child)
-        self.__dict__[cache_key] = result
+        cache[name] = result
         return result
 
     def get(self, element_name: str) -> "Element | None":  # noqa: F821

--- a/tests/unit/sam/sysml2/classes/test_sysml_element.py
+++ b/tests/unit/sam/sysml2/classes/test_sysml_element.py
@@ -138,7 +138,7 @@ class TestSysMLElementGet:
         child._name = "Part Definition"
         parent = SysMLElement("parent-id")
         parent._element_hash_map = {"Part Definition": child}
-        parent._ownedElement = [child]
+        parent._owned_names = {"Part Definition"}
         return parent, child
 
     def test_get_returns_owned_child_with_spaced_name(self):


### PR DESCRIPTION
The new SysML2 metamodel replaces `/?`-composed inherited-feature
IDs with explicit `FeatureChaining` relationships. This PR drops
the legacy `/?`-resolution machinery and adopts a uniform
hash-map plus lazy proxy-cache scheme on both flavours.

Two commits
-----------

1. `refactor: adapt builder to FeatureChaining and cache inherited
    proxies on both flavours` (8cdc826)

   - `builder/sysml2_project_builder.py`: drop the
     `/?`-resolution machinery and the `/roots` namespace flow.
   - `meta_model/e_object.py`: add `__dir__` (Jupyter `<TAB>`),
     `__getattr__`, and `_resolve_child` with proxy caching.
   - `classes/sysml_inherited_element.py`: switch
     `owned_inherited_feature` to `inherited_feature`.
   - `classes/inherited_element.py`: `__setattr__` override so
     proxy plumbing bypasses the SysMLElement observer routing.
   - `builder/mapper/sysml_mapper.py`: drop the residual
     `namespace` arg.
   - `classes/{project,scripting_project}.py`: add `id` property.

2. `perf: lazy scripting proxy cache and O(1) owned-name lookup`
   (e56b39c)

   - Scripting now follows the same lazy `_resolve_child` pattern
     as the metamodel: inherited children are wrapped in
     `InheritedElement` on first access and cached under `#name`.
     The eager `#name` setattr loop in `_resolve_inherited_link`
     is gone; autocomplete still works because `__dir__`
     exposes hash-map keys.
   - `_owned_names: set[str]` is computed once per element at
     build time, so both `EObject._resolve_child` and
     `SysMLElement._resolve_child` do O(1) owned-vs-inherited
     decisions instead of linear scans over the owned list.
   - The `name.startswith("#")` branch in `SysMLElement.__setattr__`
     is removed (no longer reachable).

Stacked on PR 2 (`refactor/183-adapt-builder-and-mappers`).
Target base is `maint/183-align-mm`.

Issue #183.