### PR TITLE
feat: add get_target/get_source on connections and fix transactional commit field names

### DIFF
--- a/doc/changelog.d/189.added.md
+++ b/doc/changelog.d/189.added.md
@@ -1,0 +1,1 @@
+Add get_target/get_source on connections and fix transactional commit field names

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -99,6 +99,29 @@ class SysMLElement:
             return None
         return self.__getattr__(element_name)
 
+    def get_target(self):
+        """Return the resolved leaf element pointed to by ``self._target``, or None."""
+        return self._resolve_end(getattr(self, "_target", []) or [])
+
+    def get_source(self):
+        """Return the resolved leaf element pointed to by ``self._source``, or None."""
+        return self._resolve_end(getattr(self, "_source", []) or [])
+
+    def _resolve_end(self, ends):
+        """Walk the first end's ``_chainingFeature`` via attribute access; passthrough direct references."""
+        if not ends:
+            return None
+        end = ends[0]
+        chain = getattr(end, "_chainingFeature", None) or []
+        if not chain:
+            return end
+        current = getattr(self, "_owner", None)
+        for hop in chain:
+            if current is None:
+                return None
+            current = getattr(current, hop._name, None)
+        return current
+
     def delete(self):
         """Delete the element from the model via the observer's commit to the server."""
         if self._observer is not None:

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -53,6 +53,10 @@ class SysMLElement:
         names = set(list(base) + children)
         if not ValueHelper.is_value_capable(self):
             names.difference_update({"get_value", "set_value", "parse_and_set_value"})
+        if not getattr(self, "_source", None):
+            names.discard("get_source")
+        if not getattr(self, "_target", None):
+            names.discard("get_target")
         return sorted(names)
 
     def __getattr__(self, name):

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -108,7 +108,7 @@ class SysMLElement:
         return self._resolve_end(getattr(self, "_source", []) or [])
 
     def _resolve_end(self, ends):
-        """Walk the first end's ``_chainingFeature`` via attribute access; passthrough direct references."""
+        """Walk the first end's ``_chainingFeature`` via attribute access; else passthrough."""
         if not ends:
             return None
         end = ends[0]

--- a/src/ansys/sam/sysml2/data_structures/observed_list.py
+++ b/src/ansys/sam/sysml2/data_structures/observed_list.py
@@ -111,6 +111,11 @@ class ObservedList(list):
         return super().reverse()
 
     @mount_observer_and_access
+    def clear(self):
+        """Override the list clear method."""
+        return super().clear()
+
+    @mount_observer_and_access
     def __iadd__(self, value):
         """Override the list __iadd__ method."""
         return super().__iadd__(value)

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -49,6 +49,10 @@ class EObject:
         names = [a for a in super().__dir__() if a != "_proxy_cache" and not a.startswith("#")]
         if not ValueHelper.is_value_capable(self):
             names = [a for a in names if a not in ("get_value", "set_value", "parse_and_set_value")]
+        if not getattr(self, "source", None):
+            names = [a for a in names if a != "get_source"]
+        if not getattr(self, "target", None):
+            names = [a for a in names if a != "get_target"]
         return sorted(names)
 
     def _resolve_child(self, name, hmap):

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -80,7 +80,7 @@ class EObject:
         return self._resolve_end(getattr(self, "source", []) or [])
 
     def _resolve_end(self, ends):
-        """Walk the first end's ``chaining_feature`` via ``self.owner.get(name)``; passthrough direct references."""
+        """Walk the first end's ``chaining_feature`` via ``self.owner.get``; else passthrough."""
         if not ends:
             return None
         end = ends[0]

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -71,6 +71,29 @@ class EObject:
             return None
         return self._resolve_child(element_name, hmap)
 
+    def get_target(self) -> "Element | None":  # noqa: F821
+        """Return the resolved leaf element pointed to by ``self.target``, or None."""
+        return self._resolve_end(getattr(self, "target", []) or [])
+
+    def get_source(self) -> "Element | None":  # noqa: F821
+        """Return the resolved leaf element pointed to by ``self.source``, or None."""
+        return self._resolve_end(getattr(self, "source", []) or [])
+
+    def _resolve_end(self, ends):
+        """Walk the first end's ``chaining_feature`` via ``self.owner.get(name)``; passthrough direct references."""
+        if not ends:
+            return None
+        end = ends[0]
+        chain = getattr(end, "chaining_feature", None) or []
+        if not chain:
+            return end
+        current = getattr(self, "owner", None)
+        for hop in chain:
+            if current is None:
+                return None
+            current = current.get(hop.name)
+        return current
+
     @property
     def id(self):
         """Get the id of the element."""

--- a/src/ansys/sam/sysml2/observer/observer.py
+++ b/src/ansys/sam/sysml2/observer/observer.py
@@ -243,7 +243,10 @@ class ModificationObserver:
             if not key.startswith("value:"):
                 change.identify(key)
             for field in changes:
-                change.add_change(field[0], field[1])
+                field_name = field[0]
+                if field_name.startswith("_"):
+                    field_name = field_name[1:]
+                change.add_change(field_name, field[1])
             commit.add_change(change)
         if len(commit.changes) > 0:
             self._connector.create_commit(self._project_id, commit.to_json())

--- a/tests/unit/sam/sysml2/classes/test_sysml_element.py
+++ b/tests/unit/sam/sysml2/classes/test_sysml_element.py
@@ -165,7 +165,7 @@ class TestSysMLElementGet:
 
 
 class TestSysMLElementDir:
-    """Value methods are listed in dir() only for value-capable (Feature) elements."""
+    """dir() lists value and connection helpers only when applicable."""
 
     def test_value_methods_hidden_on_non_feature(self):
         # The scripting mapper sets __class__ to a subclass named after the @type.
@@ -185,3 +185,24 @@ class TestSysMLElementDir:
         assert "get_value" in listing
         assert "set_value" in listing
         assert "parse_and_set_value" in listing
+
+    def test_source_target_hidden_without_ends(self):
+        element = SysMLElement("element_id")
+
+        listing = dir(element)
+        assert "get_source" not in listing
+        assert "get_target" not in listing
+
+    def test_get_source_listed_when_source_populated(self):
+        element = SysMLElement("element_id")
+        element._source = [SysMLElement("end_id")]
+
+        assert "get_source" in dir(element)
+        assert "get_target" not in dir(element)
+
+    def test_get_target_listed_when_target_populated(self):
+        element = SysMLElement("element_id")
+        element._target = [SysMLElement("end_id")]
+
+        assert "get_target" in dir(element)
+        assert "get_source" not in dir(element)

--- a/tests/unit/sam/sysml2/meta_model/test_e_object.py
+++ b/tests/unit/sam/sysml2/meta_model/test_e_object.py
@@ -37,6 +37,7 @@ _REQUIRES_NAME_WRITE_HANDLING = (
 )
 _REQUIRES_OLD_FORMAT_DROP = "old-format value path is dropped in #186 (#183)"
 
+
 class TestEObject:
 
     @pytest.fixture

--- a/tests/unit/sam/sysml2/meta_model/test_e_object.py
+++ b/tests/unit/sam/sysml2/meta_model/test_e_object.py
@@ -122,7 +122,7 @@ class TestEObject:
 
 
 class TestEObjectDir:
-    """Value methods are listed in dir() only for value-capable (Feature) elements."""
+    """dir() lists value and connection helpers only when applicable."""
 
     def test_value_methods_hidden_on_non_feature(self):
         element = Element("element_id")
@@ -147,3 +147,24 @@ class TestEObjectDir:
         assert "get_value" in listing
         assert "set_value" in listing
         assert "parse_and_set_value" in listing
+
+    def test_source_target_hidden_without_ends(self):
+        element = Element("element_id")
+
+        listing = dir(element)
+        assert "get_source" not in listing
+        assert "get_target" not in listing
+
+    def test_get_source_listed_when_source_populated(self):
+        element = Element("element_id")
+        element.source = [Element("end_id")]
+
+        assert "get_source" in dir(element)
+        assert "get_target" not in dir(element)
+
+    def test_get_target_listed_when_target_populated(self):
+        element = Element("element_id")
+        element.target = [Element("end_id")]
+
+        assert "get_target" in dir(element)
+        assert "get_source" not in dir(element)

--- a/tests/unit/sam/sysml2/tools/test_ansys_sysml2_project.py
+++ b/tests/unit/sam/sysml2/tools/test_ansys_sysml2_project.py
@@ -31,13 +31,14 @@ from ansys.sam.sysml2.tools.factory import Factory
 from tests.unit.const import PROJECT_ID_1, VALID_ORGANIZATION, VALID_TOKEN
 from tests.unit.mocked_connector import MockedSysML2APIConnector
 
+_REQUIRES_NAME_WRITE_HANDLING = (
+    "creating elements with name needs the read-only-name handling that lands in #192 (#183)"
+)
+
 
 class TestAnsysSysML2Project:
 
-    @pytest.mark.skip(
-        reason="creating elements with name needs the read-only-name handling "
-        "that lands in #192 (#183)"
-    )
+    @pytest.mark.skip(reason=_REQUIRES_NAME_WRITE_HANDLING)
     def test_streamlined_project_factory_initialization(self, mocker):
         mocker.patch(
             "ansys.sam.sysml2.tools.ansys_project.AnsysSysML2APIConnector",

--- a/tests/unit/sam/sysml2/tools/test_factory.py
+++ b/tests/unit/sam/sysml2/tools/test_factory.py
@@ -42,6 +42,10 @@ ELEMENT_TYPES = [
     ("create_state_usage", "StateUsage"),
 ]
 
+_REQUIRES_NAME_WRITE_HANDLING = (
+    "creating elements with name needs the read-only-name handling that lands in #192 (#183)"
+)
+
 
 class TestFactory:
 
@@ -69,10 +73,7 @@ class TestFactory:
 
         assert commit_spy.call_count == 1
 
-    @pytest.mark.skip(
-        reason="creating elements with name needs the read-only-name handling "
-        "that lands in #192 (#183)"
-    )
+    @pytest.mark.skip(reason=_REQUIRES_NAME_WRITE_HANDLING)
     @pytest.mark.parametrize("factory_method,element_type", ELEMENT_TYPES)
     def test_create_element_transactional_sysml(
         self, connector, factory_method, element_type, mocker


### PR DESCRIPTION
Adds ergonomic connection-navigation helpers and fixes the
transactional commit payload field names.

Changes
-------

- `classes/sysml_element.py`: add `get_target()` / `get_source()` /
  `_resolve_end()`. Walks the first end's `_chainingFeature` via
  attribute access on `self._owner`; passes through to the end
  itself when no chaining hops are present.
- `meta_model/e_object.py`: mirror methods at the metamodel
  level, walking `chaining_feature` via `current.get(hop.name)`.
- `data_structures/observed_list.py`: add an observed `clear()`
  override so a `list.clear()` on an observed field is captured.
- `observer/observer.py`: strip the leading `_` from field names
  before adding to commit changes so the server receives `name`,
  `target`, etc. instead of `_name`, `_target`.

Stacked on PR 5 (`refactor/183-feature-chaining-builder`).
Target base is the PR 5 branch until PR 5 merges; then retarget
to `maint/183-align-mm`.

Issue #183.