### PR TITLE
feat: add scripting get(name) accessor for non-dot-accessible names

### DIFF
--- a/doc/changelog.d/191.added.md
+++ b/doc/changelog.d/191.added.md
@@ -1,0 +1,1 @@
+Add scripting get(name) accessor for non-dot-accessible names

--- a/src/ansys/sam/sysml2/classes/inherited_element.py
+++ b/src/ansys/sam/sysml2/classes/inherited_element.py
@@ -68,6 +68,13 @@ class InheritedElement(SysMLElement):
         """Get the attribute list from the real element."""
         return dir(self._element)
 
+    def get(self, element_name: str):
+        """Resolve a child by name on the wrapped element, wrapping it as a proxy when needed."""
+        hmap = getattr(self._element, "_element_hash_map", {})
+        if element_name not in hmap:
+            return None
+        return self.__getattr__(element_name)
+
     def __getattr__(self, name):
         """Get the attribute from the real element."""
         if name in ("_observer", "_element", "_id", "_owner"):

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -109,6 +109,13 @@ class SysMLElement:
         """Update the feature value."""
         ValueHelper.set_or_update_value(self, type(new_value), new_value)
 
+    def get(self, element_name: str):
+        """Find an owned or inherited child by name; use for names dot access cannot express (e.g. spaces)."""
+        hmap = self.__dict__.get("_element_hash_map", {})
+        if element_name not in hmap:
+            return None
+        return self.__getattr__(element_name)
+
     def delete(self):
         """Delete the element from the model via the observer's commit to the server."""
         if self._observer is not None:

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -110,7 +110,7 @@ class SysMLElement:
         ValueHelper.set_or_update_value(self, type(new_value), new_value)
 
     def get(self, element_name: str):
-        """Find an owned or inherited child by name; use for names dot access cannot express (e.g. spaces)."""
+        """Find an owned or inherited child by name (e.g. names with spaces)."""
         hmap = self.__dict__.get("_element_hash_map", {})
         if element_name not in hmap:
             return None

--- a/tests/unit/sam/sysml2/classes/test_sysml_element.py
+++ b/tests/unit/sam/sysml2/classes/test_sysml_element.py
@@ -25,7 +25,9 @@
 import pytest
 
 from ansys.sam.sysml2.builder.sysml2_project_manager import SysML2ProjectManager
+from ansys.sam.sysml2.classes.inherited_element import InheritedElement
 from ansys.sam.sysml2.classes.scripting_project import ScriptingProject
+from ansys.sam.sysml2.classes.sysml_element import SysMLElement
 from ansys.sam.sysml2.exception.connector_exception import BadRequestConnectionException
 from ansys.sam.sysml2.exception.runtime_exception import UnsupportedValueExpression
 from tests.unit.const import PROJECT_ID_1, PROJECT_ID_3, PROJECT_ID_4
@@ -137,3 +139,38 @@ class TestSysMLElement:
 
         with pytest.raises(BadRequestConnectionException):
             root._name = ["ShouldFail"]
+
+
+class TestSysMLElementGet:
+    """The get(name) accessor reaches children whose names dot access cannot express."""
+
+    def _build_parent_with_spaced_child(self):
+        child = SysMLElement("child-id")
+        child._identifier = "child-id"
+        child._name = "Part Definition"
+        parent = SysMLElement("parent-id")
+        parent._element_hash_map = {"Part Definition": child}
+        parent._ownedElement = [child]
+        return parent, child
+
+    def test_get_returns_owned_child_with_spaced_name(self):
+        parent, child = self._build_parent_with_spaced_child()
+
+        assert parent.get("Part Definition") is child
+
+    def test_get_returns_none_for_missing_name(self):
+        parent, _ = self._build_parent_with_spaced_child()
+
+        assert parent.get("missing") is None
+
+    def test_get_through_inherited_element_proxy(self):
+        parent, _ = self._build_parent_with_spaced_child()
+        owner = SysMLElement("owner-id")
+        owner._owner = None
+        proxy = InheritedElement(owner, parent)
+
+        resolved = proxy.get("Part Definition")
+
+        assert resolved is not None
+        assert resolved._name == "Part Definition"
+        assert proxy.get("missing") is None


### PR DESCRIPTION
Scripting elements only support dot access, so a child whose name
contains characters that are not valid in a Python identifier (most
commonly spaces, e.g. `"Part Definition"`) cannot be reached. This PR
adds a `get(name)` accessor that mirrors the metamodel `EObject.get()`.

Changes
-------

- `classes/sysml_element.py`: add `get(element_name)`, which looks the
  name up in `_element_hash_map` and returns the owned child (or its
  `InheritedElement` proxy) via the existing `_resolve_child`; returns
  `None` on a miss, matching `EObject.get()`.
- `classes/inherited_element.py`: add `get(element_name)` on the proxy,
  resolving against the wrapped element's hash map and reusing the
  proxy's wrapping logic.

Tests
-----

- `tests/unit/sam/sysml2/classes/test_sysml_element.py`: a spaced-name
  child is reachable via `parent.get("Part Definition")`, a missing name
  returns `None`, and the same holds through an `InheritedElement`
  proxy.

Stacked on PR 2 (`refactor/183-adapt-builder-and-mappers`).
Target base is `maint/183-align-mm` once PR 2 merges.

Issue #183.
