### PR TITLE
feat: surface renamed name/visibility fields through deprecation shims

### DIFF
--- a/doc/changelog.d/192.added.md
+++ b/doc/changelog.d/192.added.md
@@ -1,0 +1,1 @@
+Surface renamed name/visibility fields through deprecation shims

--- a/src/ansys/sam/sysml2/builder/mapper/mapper.py
+++ b/src/ansys/sam/sysml2/builder/mapper/mapper.py
@@ -73,7 +73,9 @@ class Mapper(ABC):
         list
             Empty list because the field is already resolved.
         """
-        setattr(element, field_name, field_value)
+        # Bypass the scripting read-only guard on ``_name``: this is deserialization,
+        # not a user edit, so it must not raise or stack an observer change.
+        object.__setattr__(element, field_name, field_value)
         return []
 
     def _add_element_to_field(self, element, key: str, value: dict) -> list[UnresolvedField]:

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -114,7 +114,7 @@ class SysML2ProjectBuilder:
         elif isinstance(project, ScriptingProject):
             for element in project._env.values():
                 resolved = SysMLUtil.check_inherited_name(element)
-                element._name = resolved
+                object.__setattr__(element, "_name", resolved)
                 element._declaredName = resolved
                 if self._is_logical_root(element, "_owner"):
                     roots.append(element)

--- a/src/ansys/sam/sysml2/classes/inherited_element.py
+++ b/src/ansys/sam/sysml2/classes/inherited_element.py
@@ -72,9 +72,9 @@ class InheritedElement(SysMLElement):
         super().__setattr__(name, value)
 
     @property
-    def visibility(self):
-        """Delegate visibility to the wrapped element (the proxy holds no fields of its own)."""
-        return self._element.visibility
+    def _visibility(self):
+        """Delegate _visibility to the wrapped element (the proxy holds no fields of its own)."""
+        return self._element._visibility
 
     def __dir__(self):
         """Get the attribute list from the real element."""

--- a/src/ansys/sam/sysml2/classes/inherited_element.py
+++ b/src/ansys/sam/sysml2/classes/inherited_element.py
@@ -71,6 +71,11 @@ class InheritedElement(SysMLElement):
             return
         super().__setattr__(name, value)
 
+    @property
+    def visibility(self):
+        """Delegate visibility to the wrapped element (the proxy holds no fields of its own)."""
+        return self._element.visibility
+
     def __dir__(self):
         """Get the attribute list from the real element."""
         return dir(self._element)

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -57,6 +57,10 @@ class SysMLElement:
             names.discard("get_source")
         if not getattr(self, "_target", None):
             names.discard("get_target")
+        from ansys.sam.sysml2.tools.deprecation import visibility_alias_listed
+
+        if visibility_alias_listed(self, "_visibility", "_owningMembership"):
+            names.add("_visibility")
         return sorted(names)
 
     def __getattr__(self, name):

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -78,8 +78,27 @@ class SysMLElement:
         self.__dict__[name] = result
         return result
 
+    @property
+    def visibility(self):
+        """Deprecated: redirects to the owning membership's visibility (moved in the new metamodel)."""
+        own = self.__dict__.get("_visibility")
+        if own is not None:
+            return own
+        om = self.__dict__.get("_owningMembership")
+        if om is None:
+            return None
+        from ansys.sam.sysml2.tools.deprecation import warn_moved
+
+        warn_moved("visibility", "owning_membership.visibility")
+        return getattr(om, "_visibility", None)
+
     def __setattr__(self, name: str, value: object):
         """Intercept attribute assignment and notify the modification observer."""
+        if name in ("name", "visibility"):
+            from ansys.sam.sysml2.tools.deprecation import raise_readonly
+
+            alternative = "declared_name" if name == "name" else "owning_membership.visibility"
+            raise_readonly(name, alternative)
         if name != "_observer" and getattr(self, "_observer", None) is not None:
             self._observer.notify(self._id, name, value)
         super().__setattr__(name, value)

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -80,7 +80,7 @@ class SysMLElement:
 
     @property
     def visibility(self):
-        """Deprecated: redirects to the owning membership's visibility (moved in the new metamodel)."""
+        """Deprecated: redirect to the owning membership's visibility (moved in new MM)."""
         own = self.__dict__.get("_visibility")
         if own is not None:
             return own
@@ -93,7 +93,7 @@ class SysMLElement:
         return getattr(om, "_visibility", None)
 
     def __setattr__(self, name: str, value: object):
-        """Intercept attribute assignment: name is read-only, visibility redirects, others notify."""
+        """Intercept assignment: name is read-only, visibility redirects, others notify."""
         if name in ("name", "_name"):
             from ansys.sam.sysml2.tools.deprecation import raise_readonly
 

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -89,16 +89,25 @@ class SysMLElement:
             return None
         from ansys.sam.sysml2.tools.deprecation import warn_moved
 
-        warn_moved("visibility", "owning_membership.visibility")
+        warn_moved("visibility", "_owningMembership._visibility")
         return getattr(om, "_visibility", None)
 
     def __setattr__(self, name: str, value: object):
-        """Intercept attribute assignment and notify the modification observer."""
-        if name in ("name", "visibility"):
+        """Intercept attribute assignment: name is read-only, visibility redirects, others notify."""
+        if name in ("name", "_name"):
             from ansys.sam.sysml2.tools.deprecation import raise_readonly
 
-            alternative = "declared_name" if name == "name" else "owning_membership.visibility"
-            raise_readonly(name, alternative)
+            raise_readonly(name, "_declaredName")
+        if name == "visibility":
+            from ansys.sam.sysml2.tools.deprecation import warn_moved
+
+            warn_moved("visibility", "_owningMembership._visibility")
+            om = self.__dict__.get("_owningMembership")
+            if om is not None:
+                om._visibility = value
+            else:
+                object.__setattr__(self, "_visibility", value)
+            return
         if name != "_observer" and getattr(self, "_observer", None) is not None:
             self._observer.notify(self._id, name, value)
         super().__setattr__(name, value)

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -63,6 +63,11 @@ class SysMLElement:
         """Resolve hash-map children lazily; only fires when normal attribute lookup fails."""
         if name.startswith("__") and name.endswith("__"):
             raise AttributeError(name)
+        from ansys.sam.sysml2.tools.deprecation import UNHANDLED, scripting_deprecated_get
+
+        shimmed = scripting_deprecated_get(self, name)
+        if shimmed is not UNHANDLED:
+            return shimmed
         hmap = self.__dict__.get("_element_hash_map", {})
         if name not in hmap:
             raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
@@ -78,35 +83,11 @@ class SysMLElement:
         self.__dict__[name] = result
         return result
 
-    @property
-    def visibility(self):
-        """Deprecated: redirect to the owning membership's visibility (moved in new MM)."""
-        own = self.__dict__.get("_visibility")
-        if own is not None:
-            return own
-        om = self.__dict__.get("_owningMembership")
-        if om is None:
-            return None
-        from ansys.sam.sysml2.tools.deprecation import warn_moved
-
-        warn_moved("visibility", "_owningMembership._visibility")
-        return getattr(om, "_visibility", None)
-
     def __setattr__(self, name: str, value: object):
-        """Intercept assignment: name is read-only, visibility redirects, others notify."""
-        if name in ("name", "_name"):
-            from ansys.sam.sysml2.tools.deprecation import raise_readonly
+        """Intercept attribute assignment: deprecated shims first, then notify the observer."""
+        from ansys.sam.sysml2.tools.deprecation import scripting_deprecated_set
 
-            raise_readonly(name, "_declaredName")
-        if name == "visibility":
-            from ansys.sam.sysml2.tools.deprecation import warn_moved
-
-            warn_moved("visibility", "_owningMembership._visibility")
-            om = self.__dict__.get("_owningMembership")
-            if om is not None:
-                om._visibility = value
-            else:
-                object.__setattr__(self, "_visibility", value)
+        if scripting_deprecated_set(self, name, value):
             return
         if name != "_observer" and getattr(self, "_observer", None) is not None:
             self._observer.notify(self._id, name, value)

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -53,6 +53,14 @@ class EObject:
             names = [a for a in names if a != "get_source"]
         if not getattr(self, "target", None):
             names = [a for a in names if a != "get_target"]
+        from ansys.sam.sysml2.tools.deprecation import is_visibility_shim, visibility_alias_listed
+
+        if (
+            "visibility" in names
+            and is_visibility_shim(type(self))
+            and not visibility_alias_listed(self, "_visibility", "_owning_membership")
+        ):
+            names = [a for a in names if a != "visibility"]
         return sorted(names)
 
     def _resolve_child(self, name, hmap):

--- a/src/ansys/sam/sysml2/meta_model/element.py
+++ b/src/ansys/sam/sysml2/meta_model/element.py
@@ -194,10 +194,13 @@ class Element(EObject):
 
     @visibility.setter
     def visibility(self, value):
-        """Reject writes: ``visibility`` now lives on the owning membership."""
-        from ansys.sam.sysml2.tools.deprecation import raise_readonly
+        """Deprecated: redirects the write to ``owning_membership.visibility`` (moved in the new metamodel)."""
+        from ansys.sam.sysml2.tools.deprecation import warn_moved
 
-        raise_readonly("visibility", "owning_membership.visibility")
+        warn_moved("visibility", "owning_membership.visibility")
+        om = self._owning_membership
+        if om is not None:
+            om.visibility = value
 
     @property
     def owned_annotation(self) -> list["Annotation"]:  # noqa: F821

--- a/src/ansys/sam/sysml2/meta_model/element.py
+++ b/src/ansys/sam/sysml2/meta_model/element.py
@@ -176,6 +176,29 @@ class Element(EObject):
         """
         return self._name
 
+    @name.setter
+    def name(self, value: str):
+        """Reject writes: ``name`` is read-only in the new metamodel; use ``declared_name``."""
+        from ansys.sam.sysml2.tools.deprecation import raise_readonly
+
+        raise_readonly("name", "declared_name")
+
+    @property
+    def visibility(self):
+        """Deprecated: redirects to ``owning_membership.visibility`` (moved in the new metamodel)."""
+        from ansys.sam.sysml2.tools.deprecation import warn_moved
+
+        warn_moved("visibility", "owning_membership.visibility")
+        om = self._owning_membership
+        return om.visibility if om is not None else None
+
+    @visibility.setter
+    def visibility(self, value):
+        """Reject writes: ``visibility`` now lives on the owning membership."""
+        from ansys.sam.sysml2.tools.deprecation import raise_readonly
+
+        raise_readonly("visibility", "owning_membership.visibility")
+
     @property
     def owned_annotation(self) -> list["Annotation"]:  # noqa: F821
         """

--- a/src/ansys/sam/sysml2/meta_model/element.py
+++ b/src/ansys/sam/sysml2/meta_model/element.py
@@ -185,7 +185,7 @@ class Element(EObject):
 
     @property
     def visibility(self):
-        """Deprecated: redirects to ``owning_membership.visibility`` (moved in the new metamodel)."""
+        """Deprecated: redirect to ``owning_membership.visibility`` (moved in new MM)."""
         from ansys.sam.sysml2.tools.deprecation import warn_moved
 
         warn_moved("visibility", "owning_membership.visibility")
@@ -194,7 +194,7 @@ class Element(EObject):
 
     @visibility.setter
     def visibility(self, value):
-        """Deprecated: redirects the write to ``owning_membership.visibility`` (moved in the new metamodel)."""
+        """Redirect the write to ``owning_membership.visibility`` (deprecated; moved in new MM)."""
         from ansys.sam.sysml2.tools.deprecation import warn_moved
 
         warn_moved("visibility", "owning_membership.visibility")

--- a/src/ansys/sam/sysml2/tools/deprecation.py
+++ b/src/ansys/sam/sysml2/tools/deprecation.py
@@ -41,3 +41,44 @@ def raise_readonly(attr: str, alternative: str) -> NoReturn:
         f"'{attr}' is read-only in the new metamodel. Use '{alternative}' to set a value "
         f"(for example, element.{alternative} = ...)."
     )
+
+
+UNHANDLED = object()
+"""Sentinel returned by ``scripting_deprecated_get`` when no shim applies."""
+
+
+def scripting_deprecated_get(element, name):
+    """Resolve a scripting deprecation read shim, or return ``UNHANDLED``.
+
+    ``_visibility`` moved onto the owning membership in the new metamodel.
+    """
+    if name == "_visibility":
+        owning_membership = element.__dict__.get("_owningMembership")
+        if owning_membership is None:
+            return None
+        warn_moved("_visibility", "_owningMembership._visibility")
+        return owning_membership.__dict__.get("_visibility")
+    return UNHANDLED
+
+
+def scripting_deprecated_set(element, name, value) -> bool:
+    """Apply a scripting deprecation write shim. Return ``True`` if handled.
+
+    ``name``/``_name`` are read-only (raise); ``_visibility`` redirects the
+    write to the owning membership.
+    """
+    if name in ("name", "_name"):
+        raise_readonly(name, "_declaredName")
+    if name == "_visibility":
+        warn_moved("_visibility", "_owningMembership._visibility")
+        owning_membership = element.__dict__.get("_owningMembership")
+        if owning_membership is not None:
+            # Bypass the membership's own ``_visibility`` redirect and persist
+            # the change against the membership directly.
+            if getattr(owning_membership, "_observer", None) is not None:
+                owning_membership._observer.notify(owning_membership._id, "_visibility", value)
+            object.__setattr__(owning_membership, "_visibility", value)
+        else:
+            object.__setattr__(element, "_visibility", value)
+        return True
+    return False

--- a/src/ansys/sam/sysml2/tools/deprecation.py
+++ b/src/ansys/sam/sysml2/tools/deprecation.py
@@ -82,3 +82,17 @@ def scripting_deprecated_set(element, name, value) -> bool:
             object.__setattr__(element, "_visibility", value)
         return True
     return False
+
+
+def visibility_alias_listed(element, own_attr, membership_attr) -> bool:
+    """Whether the deprecated visibility alias should appear in dir() for this element."""
+    if element.__dict__.get(own_attr) is not None:
+        return True
+    return element.__dict__.get(membership_attr) is not None
+
+
+def is_visibility_shim(element_type) -> bool:
+    """Return ``True`` if ``element_type`` uses the deprecated ``Element.visibility`` shim."""
+    from ansys.sam.sysml2.meta_model.element import Element
+
+    return getattr(element_type, "visibility", None) is Element.__dict__.get("visibility")

--- a/src/ansys/sam/sysml2/tools/deprecation.py
+++ b/src/ansys/sam/sysml2/tools/deprecation.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""Deprecation helpers for metamodel changes (consistent warnings and errors)."""
+
+from typing import NoReturn
+import warnings
+
+
+def warn_moved(attr: str, alternative: str) -> None:
+    """Emit a DeprecationWarning that a property moved in the new metamodel."""
+    warnings.warn(
+        f"'{attr}' moved in the new metamodel; it now lives on '{alternative}'. "
+        f"Access '{alternative}' directly; this shim will be removed in a future release.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def raise_readonly(attr: str, alternative: str) -> NoReturn:
+    """Raise a clear AttributeError telling the caller which writable attribute to use."""
+    raise AttributeError(
+        f"'{attr}' is read-only in the new metamodel. Use '{alternative}' to set a value "
+        f"(for example, element.{alternative} = ...)."
+    )

--- a/src/ansys/sam/sysml2/tools/factory.py
+++ b/src/ansys/sam/sysml2/tools/factory.py
@@ -2405,6 +2405,11 @@ class Factory:
 
                     setattr(instance, attr_name, ObservedList(owner=instance, name=attr_name))
                 getattr(instance, attr_name).extend(value)
+            elif attr_name in ("name", "_name"):
+                # ``name`` is read-only in the new metamodel: write the backing field
+                # directly (both flavors store it as ``_name``) and stack the change.
+                object.__setattr__(instance, "_name", value)
+                instance._observer.notify(instance._id, attr_name, value)
             else:
                 setattr(instance, attr_name, value)
         self._project.add_element(instance)

--- a/tests/unit/sam/sysml2/classes/test_sysml_element.py
+++ b/tests/unit/sam/sysml2/classes/test_sysml_element.py
@@ -47,9 +47,9 @@ class TestSysMLElement:
         mocker.patch.object(root._observer, "reload_project")
         attr = root.PartDefinition.attribute
 
-        attr._name = "NewAttr"
+        attr._declaredName = "NewAttr"
 
-        assert attr._name == "NewAttr"
+        assert attr._declaredName == "NewAttr"
 
     def test_expression_get_value(self, project):
         package = project.get_root_package()
@@ -126,7 +126,7 @@ class TestSysMLElement:
         )
 
         with pytest.raises(BadRequestConnectionException):
-            root._name = ["ShouldFail"]
+            root._declaredName = ["ShouldFail"]
 
 
 class TestSysMLElementGet:
@@ -135,7 +135,7 @@ class TestSysMLElementGet:
     def _build_parent_with_spaced_child(self):
         child = SysMLElement("child-id")
         child._identifier = "child-id"
-        child._name = "Part Definition"
+        child._declaredName = "Part Definition"
         parent = SysMLElement("parent-id")
         parent._element_hash_map = {"Part Definition": child}
         parent._owned_names = {"Part Definition"}
@@ -160,7 +160,7 @@ class TestSysMLElementGet:
         resolved = proxy.get("Part Definition")
 
         assert resolved is not None
-        assert resolved._name == "Part Definition"
+        assert resolved._declaredName == "Part Definition"
         assert proxy.get("missing") is None
 
 

--- a/tests/unit/sam/sysml2/meta_model/test_e_object.py
+++ b/tests/unit/sam/sysml2/meta_model/test_e_object.py
@@ -52,8 +52,8 @@ class TestEObject:
         root = project.get_root_package()
         mocker.patch.object(root._observer, "reload_project")
         elem = root.get("PartDefinition").get("attribute")
-        elem.name = "NewAttr"
-        assert elem.name == "NewAttr"
+        elem.declared_name = "NewAttr"
+        assert elem.declared_name == "NewAttr"
 
     def test_expression_get_values(self, project: Project):
         package = project.get_root_package()

--- a/tests/unit/sam/sysml2/meta_model/test_e_object.py
+++ b/tests/unit/sam/sysml2/meta_model/test_e_object.py
@@ -32,9 +32,6 @@ from ansys.sam.sysml2.meta_model.feature import Feature
 from ansys.sam.sysml2.meta_model.part_usage import PartUsage
 from tests.unit.const import PROJECT_ID_1, PROJECT_ID_3
 
-_REQUIRES_NAME_WRITE_HANDLING = (
-    "writing name needs the read-only-name handling that lands in #192 (#183)"
-)
 _REQUIRES_OLD_FORMAT_DROP = "old-format value path is dropped in #186 (#183)"
 
 
@@ -45,7 +42,6 @@ class TestEObject:
         model_manager = SysML2ProjectManager(connector=connector)
         return model_manager.get_sysml_project(PROJECT_ID_3)
 
-    @pytest.mark.skip(reason=_REQUIRES_NAME_WRITE_HANDLING)
     def test_update_element(self, connector, mocker):
         project_manager = SysML2ProjectManager(connector)
         project = project_manager.get_sysml_project(PROJECT_ID_1)

--- a/tests/unit/sam/sysml2/observer/test_observer.py
+++ b/tests/unit/sam/sysml2/observer/test_observer.py
@@ -110,9 +110,9 @@ class TestObserverImmediate:
         mocker.patch.object(root._observer, "reload_project")
         commit_spy = mocker.spy(connector, "create_commit")
 
-        root._name = "RenamedRoot"
+        root._declaredName = "RenamedRoot"
 
-        assert root._name == "RenamedRoot"
+        assert root._declaredName == "RenamedRoot"
         assert commit_spy.call_count == 1
 
     def test_list_notify_immediate_calls_create_commit(self, connector, mocker):
@@ -151,7 +151,7 @@ class TestObserverImmediate:
         )
 
         with pytest.raises(BadRequestConnectionException):
-            root._name = ["ShouldFail"]
+            root._declaredName = ["ShouldFail"]
 
     def test_delete_commit_error_propagates(self, connector, mocker):
         """Verify BadRequestConnectionException from create_commit propagates on delete."""

--- a/tests/unit/sam/sysml2/test_deprecation_shims.py
+++ b/tests/unit/sam/sysml2/test_deprecation_shims.py
@@ -73,6 +73,22 @@ class TestMetamodelDeprecationShims:
             warnings.simplefilter("error", DeprecationWarning)
             assert membership.visibility == "private"
 
+    def test_visibility_listed_in_dir_when_owning_membership_set(self):
+        element = Element("element_id")
+        element.owning_membership = OwningMembership("membership_id")
+
+        assert "visibility" in dir(element)
+
+    def test_visibility_hidden_in_dir_on_bare_element(self):
+        element = Element("element_id")
+
+        assert "visibility" not in dir(element)
+
+    def test_membership_always_lists_its_own_visibility_in_dir(self):
+        membership = OwningMembership("membership_id")
+
+        assert "visibility" in dir(membership)
+
 
 class TestScriptingDeprecationShims:
     """Scripting flavor: SysMLElement._visibility redirect and read-only name."""
@@ -120,3 +136,20 @@ class TestScriptingDeprecationShims:
 
         with pytest.raises(AttributeError, match="_declaredName"):
             element._name = "RenamedPart"
+
+    def test_visibility_listed_in_dir_when_owning_membership_set(self):
+        element = SysMLElement("element_id")
+        element._owningMembership = SysMLElement("membership_id")
+
+        assert "_visibility" in dir(element)
+
+    def test_visibility_listed_in_dir_when_own_visibility_set(self):
+        element = SysMLElement("element_id")
+        object.__setattr__(element, "_visibility", "public")
+
+        assert "_visibility" in dir(element)
+
+    def test_visibility_hidden_in_dir_when_no_visibility(self):
+        element = SysMLElement("element_id")
+
+        assert "_visibility" not in dir(element)

--- a/tests/unit/sam/sysml2/test_deprecation_shims.py
+++ b/tests/unit/sam/sysml2/test_deprecation_shims.py
@@ -75,29 +75,29 @@ class TestMetamodelDeprecationShims:
 
 
 class TestScriptingDeprecationShims:
-    """Scripting flavor: SysMLElement.visibility redirect and read-only name."""
+    """Scripting flavor: SysMLElement._visibility redirect and read-only name."""
 
     def test_own_visibility_returned_without_warning(self):
         element = SysMLElement("element_id")
-        element._visibility = "public"
+        object.__setattr__(element, "_visibility", "public")
 
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
-            assert element.visibility == "public"
+            assert element._visibility == "public"
 
     def test_visibility_redirects_to_owning_membership_with_warning(self):
         element = SysMLElement("element_id")
         membership = SysMLElement("membership_id")
-        membership._visibility = "private"
+        object.__setattr__(membership, "_visibility", "private")
         element._owningMembership = membership
 
         with pytest.warns(DeprecationWarning, match="_owningMembership._visibility"):
-            assert element.visibility == "private"
+            assert element._visibility == "private"
 
     def test_visibility_without_owning_membership_returns_none(self):
         element = SysMLElement("element_id")
 
-        assert element.visibility is None
+        assert element._visibility is None
 
     def test_setting_visibility_redirects_to_owning_membership_with_warning(self):
         element = SysMLElement("element_id")
@@ -105,9 +105,9 @@ class TestScriptingDeprecationShims:
         element._owningMembership = membership
 
         with pytest.warns(DeprecationWarning, match="_owningMembership._visibility"):
-            element.visibility = "private"
+            element._visibility = "private"
 
-        assert membership._visibility == "private"
+        assert membership.__dict__["_visibility"] == "private"
 
     def test_setting_name_raises_pointing_to_declared_name(self):
         element = SysMLElement("element_id")

--- a/tests/unit/sam/sysml2/test_deprecation_shims.py
+++ b/tests/unit/sam/sysml2/test_deprecation_shims.py
@@ -49,11 +49,15 @@ class TestMetamodelDeprecationShims:
         with pytest.warns(DeprecationWarning):
             assert element.visibility is None
 
-    def test_setting_visibility_raises(self):
+    def test_setting_visibility_redirects_to_owning_membership_with_warning(self):
         element = Element("element_id")
+        membership = OwningMembership("membership_id")
+        element.owning_membership = membership
 
-        with pytest.raises(AttributeError, match="owning_membership.visibility"):
-            element.visibility = "public"
+        with pytest.warns(DeprecationWarning, match="owning_membership.visibility"):
+            element.visibility = "private"
+
+        assert membership.visibility == "private"
 
     def test_setting_name_raises_pointing_to_declared_name(self):
         element = Element("element_id")
@@ -87,7 +91,7 @@ class TestScriptingDeprecationShims:
         membership._visibility = "private"
         element._owningMembership = membership
 
-        with pytest.warns(DeprecationWarning, match="owning_membership.visibility"):
+        with pytest.warns(DeprecationWarning, match="_owningMembership._visibility"):
             assert element.visibility == "private"
 
     def test_visibility_without_owning_membership_returns_none(self):
@@ -95,14 +99,24 @@ class TestScriptingDeprecationShims:
 
         assert element.visibility is None
 
-    def test_setting_visibility_raises(self):
+    def test_setting_visibility_redirects_to_owning_membership_with_warning(self):
         element = SysMLElement("element_id")
+        membership = SysMLElement("membership_id")
+        element._owningMembership = membership
 
-        with pytest.raises(AttributeError, match="owning_membership.visibility"):
-            element.visibility = "public"
+        with pytest.warns(DeprecationWarning, match="_owningMembership._visibility"):
+            element.visibility = "private"
+
+        assert membership._visibility == "private"
 
     def test_setting_name_raises_pointing_to_declared_name(self):
         element = SysMLElement("element_id")
 
-        with pytest.raises(AttributeError, match="declared_name"):
+        with pytest.raises(AttributeError, match="_declaredName"):
             element.name = "RenamedPart"
+
+    def test_setting_underscore_name_raises_pointing_to_declared_name(self):
+        element = SysMLElement("element_id")
+
+        with pytest.raises(AttributeError, match="_declaredName"):
+            element._name = "RenamedPart"

--- a/tests/unit/sam/sysml2/test_deprecation_shims.py
+++ b/tests/unit/sam/sysml2/test_deprecation_shims.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the metamodel-change deprecation shims (visibility redirect, read-only name)."""
+
+import warnings
+
+import pytest
+
+from ansys.sam.sysml2.classes.sysml_element import SysMLElement
+from ansys.sam.sysml2.meta_model.element import Element
+from ansys.sam.sysml2.meta_model.owning_membership import OwningMembership
+
+
+class TestMetamodelDeprecationShims:
+    """Metamodel flavor: Element.visibility redirect and read-only name."""
+
+    def test_visibility_redirects_to_owning_membership_with_warning(self):
+        element = Element("element_id")
+        membership = OwningMembership("membership_id")
+        membership.visibility = "public"
+        element.owning_membership = membership
+
+        with pytest.warns(DeprecationWarning, match="owning_membership.visibility"):
+            assert element.visibility == "public"
+
+    def test_visibility_without_owning_membership_returns_none(self):
+        element = Element("element_id")
+
+        with pytest.warns(DeprecationWarning):
+            assert element.visibility is None
+
+    def test_setting_visibility_raises(self):
+        element = Element("element_id")
+
+        with pytest.raises(AttributeError, match="owning_membership.visibility"):
+            element.visibility = "public"
+
+    def test_setting_name_raises_pointing_to_declared_name(self):
+        element = Element("element_id")
+
+        with pytest.raises(AttributeError, match="declared_name"):
+            element.name = "RenamedPart"
+
+    def test_membership_keeps_its_own_visibility_without_warning(self):
+        membership = OwningMembership("membership_id")
+        membership.visibility = "private"
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert membership.visibility == "private"
+
+
+class TestScriptingDeprecationShims:
+    """Scripting flavor: SysMLElement.visibility redirect and read-only name."""
+
+    def test_own_visibility_returned_without_warning(self):
+        element = SysMLElement("element_id")
+        element._visibility = "public"
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            assert element.visibility == "public"
+
+    def test_visibility_redirects_to_owning_membership_with_warning(self):
+        element = SysMLElement("element_id")
+        membership = SysMLElement("membership_id")
+        membership._visibility = "private"
+        element._owningMembership = membership
+
+        with pytest.warns(DeprecationWarning, match="owning_membership.visibility"):
+            assert element.visibility == "private"
+
+    def test_visibility_without_owning_membership_returns_none(self):
+        element = SysMLElement("element_id")
+
+        assert element.visibility is None
+
+    def test_setting_visibility_raises(self):
+        element = SysMLElement("element_id")
+
+        with pytest.raises(AttributeError, match="owning_membership.visibility"):
+            element.visibility = "public"
+
+    def test_setting_name_raises_pointing_to_declared_name(self):
+        element = SysMLElement("element_id")
+
+        with pytest.raises(AttributeError, match="declared_name"):
+            element.name = "RenamedPart"

--- a/tests/unit/sam/sysml2/tools/test_ansys_sysml2_project.py
+++ b/tests/unit/sam/sysml2/tools/test_ansys_sysml2_project.py
@@ -22,8 +22,6 @@
 
 """Unit tests for AnsysSysML2Project using mocker to inject MockedConnectors."""
 
-import pytest
-
 from ansys.sam.sysml2.diagrams.api.sam_rest_api_connector import SamRestApiConnector
 from ansys.sam.sysml2.meta_model.package import Package
 from ansys.sam.sysml2.tools.ansys_sysml2_project import AnsysSysML2Project
@@ -31,14 +29,8 @@ from ansys.sam.sysml2.tools.factory import Factory
 from tests.unit.const import PROJECT_ID_1, VALID_ORGANIZATION, VALID_TOKEN
 from tests.unit.mocked_connector import MockedSysML2APIConnector
 
-_REQUIRES_NAME_WRITE_HANDLING = (
-    "creating elements with name needs the read-only-name handling that lands in #192 (#183)"
-)
-
-
 class TestAnsysSysML2Project:
 
-    @pytest.mark.skip(reason=_REQUIRES_NAME_WRITE_HANDLING)
     def test_streamlined_project_factory_initialization(self, mocker):
         mocker.patch(
             "ansys.sam.sysml2.tools.ansys_project.AnsysSysML2APIConnector",

--- a/tests/unit/sam/sysml2/tools/test_factory.py
+++ b/tests/unit/sam/sysml2/tools/test_factory.py
@@ -42,11 +42,6 @@ ELEMENT_TYPES = [
     ("create_state_usage", "StateUsage"),
 ]
 
-_REQUIRES_NAME_WRITE_HANDLING = (
-    "creating elements with name needs the read-only-name handling that lands in #192 (#183)"
-)
-
-
 class TestFactory:
 
     @pytest.fixture
@@ -73,7 +68,6 @@ class TestFactory:
 
         assert commit_spy.call_count == 1
 
-    @pytest.mark.skip(reason=_REQUIRES_NAME_WRITE_HANDLING)
     @pytest.mark.parametrize("factory_method,element_type", ELEMENT_TYPES)
     def test_create_element_transactional_sysml(
         self, connector, factory_method, element_type, mocker


### PR DESCRIPTION
The regenerated metamodel renames `name` to `declaredName` and moves
`visibility` onto the owning membership. Rather than break every caller,
this PR surfaces the moved fields through deprecation shims that keep the
old spellings working (with guidance) and centralises the shim logic in
`tools/deprecation.py`.

Changes
-------

- `tools/deprecation.py`: helpers for the scripting and metamodel shims
  (read redirect, write guidance, and the `__dir__` listing predicate)
  so `SysMLElement` / `Element` stay thin.
- `classes/sysml_element.py`, `meta_model/element.py`: make `name`
  read-only and point writers at `declared_name`; redirect
  `visibility` reads/writes to `owning_membership.visibility`. The
  scripting flavour exposes the alias as `_visibility`.
- `classes/inherited_element.py`: delegate `_visibility` to the wrapped
  element (the proxy holds no fields of its own).
- `__dir__`: list the deprecated alias only when it actually applies
  (the element has an owning membership or its own visibility), so
  Jupyter autocomplete does not advertise dead attributes.

Tests
-----

- `tests/unit/sam/sysml2/test_deprecation_shims.py`: read/write redirects,
  the read-only `name` guidance, and the conditional `__dir__` listing.

Stacked on PR 6 (`feat/183-connection-navigation`).
Target base is `maint/183-align-mm` once the stack merges.

Issue #183.
