### PR TITLE
fix: make IPython autocomplete honor element __dir__ via complete_object hook

### DIFF
--- a/doc/changelog.d/193.fixed.md
+++ b/doc/changelog.d/193.fixed.md
@@ -1,0 +1,1 @@
+Make IPython autocomplete honor element __dir__ via complete_object hook

--- a/src/ansys/sam/sysml2/__init__.py
+++ b/src/ansys/sam/sysml2/__init__.py
@@ -47,20 +47,36 @@ from ansys.sam.sysml2.diagrams.sam_diagram_manager import (  # noqa: F401, E402 
 # ------------------------------------------------------------------------------
 
 
-def _patch_completer():
-    """Disable Jedi and enable greedy completion in IPython.
+def _complete_element_attrs(obj, prev_completions):
+    """Return the element's own ``__dir__`` so conditional gating wins over IPython ``dir2()``."""
+    try:
+        return list(obj.__dir__())
+    except Exception:
+        return prev_completions
 
-    Jedi performs static analysis and ignores ``__dir__``/``__getattr__``.
-    Disabling it makes IPython call ``__dir__()`` on live objects, which is
-    required for dynamic autocompletion on SysML proxy elements.
-    """
+
+def _patch_completer():
+    """Disable Jedi, enable greedy completion, and make IPython honor the element ``__dir__``."""
     try:
         ip = get_ipython()  # noqa: F821
-        if ip is not None:
-            ip.Completer.use_jedi = False
-            ip.Completer.greedy = True
     except NameError:
-        pass
+        return
+    if ip is None:
+        return
+    ip.Completer.use_jedi = False
+    ip.Completer.greedy = True
+    try:
+        from IPython.utils.generics import complete_object
+
+        from ansys.sam.sysml2.classes.sysml_element import SysMLElement
+        from ansys.sam.sysml2.meta_model.e_object import EObject
+    except ImportError:
+        return
+    register = getattr(complete_object, "register", None)
+    if register is None:
+        register = complete_object.when_type
+    register(SysMLElement, _complete_element_attrs)
+    register(EObject, _complete_element_attrs)
 
 
 _patch_completer()

--- a/tests/unit/sam/sysml2/test_completer.py
+++ b/tests/unit/sam/sysml2/test_completer.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2024 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the IPython completion hook that makes the element __dir__ authoritative."""
+
+from ansys.sam.sysml2 import _complete_element_attrs
+from ansys.sam.sysml2.classes.sysml_element import SysMLElement
+
+
+class TestCompleteElementAttrs:
+    """``_complete_element_attrs`` must return the element's own ``__dir__``."""
+
+    def test_returns_object_dir_not_class_dir_union(self):
+        element = SysMLElement("element_id")
+
+        assert _complete_element_attrs(element, ["get_source", "get_value"]) == sorted(
+            element.__dir__()
+        )
+
+    def test_fallback_returns_prev_completions_on_error(self):
+        class Broken:
+            def __dir__(self):
+                raise RuntimeError("boom")
+
+        prev = ["a", "b"]
+
+        assert _complete_element_attrs(Broken(), prev) is prev


### PR DESCRIPTION
With `use_jedi=False`, IPython builds completion candidates from
`dir2(obj) = set(dir(obj)) | set(dir(type(obj)))`, which re-adds real
class methods even when an instance `__dir__` filtered them out. This
defeats the conditional `__dir__` gating used on SysML elements (only
showing `get_source`/`get_target` on connections, value methods on
features, deprecated aliases when applicable). This PR makes the
instance `__dir__` authoritative for autocomplete.

Changes
-------

- `src/ansys/sam/sysml2/__init__.py`: register a `complete_object`
  handler (`IPython.utils.generics`) for `SysMLElement` and `EObject`
  that returns the object's own `__dir__()`, so the gated listing wins
  over `dir2()`. Falls back to the previous completions on any error
  and is a no-op outside IPython.

Tests
-----

- `tests/unit/sam/sysml2/test_completer.py`: the hook returns the
  element's own `__dir__` (not the class-union) and falls back to the
  previous completions when `__dir__` raises.

Note
----

This is the cross-cutting completer hook only. The per-method `__dir__`
gating lives in its owner PRs: connection getters in #189, value
methods in #186, the visibility alias in #192. This PR therefore needs
both #186 and #189 to be present for the full gated experience; merge
it after them.

Stacked on #192 (`feat/183-deprecation-shims`).

Issue #183.
