### PR TITLE
chore: drop Python 3.10 and 3.11 based on SPEC-0 and internal reqs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: "Build a wheelhouse of the Python library"
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - name: "Run pytest"

--- a/.pylintrc.toml
+++ b/.pylintrc.toml
@@ -83,7 +83,7 @@ persistent = true
 
 # Minimum Python version to use for version dependent checks. Will default to the
 # version used to run pylint.
-py-version = "3.10"
+py-version = "3.12"
 
 # Discover python modules and packages in the file system subtree.
 # recursive =

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ PySAM SysML2 works with the Ansys SysML2 modeling tool, `Ansys System Architectu
 Prerequisites
 =============
 
-PySAM SysML2 requires `Python <https://www.python.org/downloads/>`_ 3.10 or later.
+PySAM SysML2 requires `Python <https://www.python.org/downloads/>`_ 3.12 or later.
 
 Documentation
 =============

--- a/doc/changelog.d/200.maintenance.md
+++ b/doc/changelog.d/200.maintenance.md
@@ -1,0 +1,1 @@
+Drop Python 3.10 and 3.11 based on SPEC-0 and internal reqs

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -217,7 +217,7 @@ Before submitting a pull request, ensure all quality checks pass:
 5. **Check documentation style**: ``cd doc; vale sync; vale .``
 6. **Run pre-commit checks**: ``prek run --all-files``
 
-The CI/CD pipeline automatically run these checks on multiple Python versions (3.10, 3.11, 3.12, 3.13, and 3.14) when you submit your pull request.
+The CI/CD pipeline automatically run these checks on multiple Python versions (3.12, 3.13, and 3.14) when you submit your pull request.
 
 .. note::
    While you can run tests locally on your installed Python version, the CI/CD pipeline ensures compatibility across all supported Python versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-sam-sysml2"
 version = "0.1.dev0"
 description = "Python library for Sysml2 model manipulation"
 readme = "README.rst"
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.12,<4.0"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
@@ -18,8 +18,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Topic :: Software Development :: Libraries",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",


### PR DESCRIPTION
Following drop of Python 3.10 internally and guidelines from SPEC-0, we can now drop support for 3.10 and 3.11 safely
Issue: #195