### PR TITLE
feat: add opt-in resolve_libraries flag to load and map library element contents

### DIFF
--- a/doc/changelog.d/207.added.md
+++ b/doc/changelog.d/207.added.md
@@ -1,0 +1,1 @@
+Add opt-in resolve_libraries flag to load and map library element contents

--- a/src/ansys/sam/sysml2/builder/classes/project_impl.py
+++ b/src/ansys/sam/sysml2/builder/classes/project_impl.py
@@ -38,6 +38,7 @@ class ProjectImpl(Project):
     _root: list[Element]
     _unresolved_fields: list[UnresolvedField]
     _name: str
+    _resolve_libraries: bool = False
 
     def __init__(self, project_id: str, name: str):
         """

--- a/src/ansys/sam/sysml2/builder/classes/scripting_project_impl.py
+++ b/src/ansys/sam/sysml2/builder/classes/scripting_project_impl.py
@@ -36,6 +36,7 @@ class ScriptingProjectImpl(ScriptingProject):
     _root: list[SysMLElement]
     _unresolved_fields: list[UnresolvedField]
     _name: str
+    _resolve_libraries: bool = False
 
     def __init__(self, project_id: str, name: str):
         """

--- a/src/ansys/sam/sysml2/builder/mapper/mapper.py
+++ b/src/ansys/sam/sysml2/builder/mapper/mapper.py
@@ -39,6 +39,7 @@ class Mapper(ABC):
         self,
         json_element: dict,
         mapped_element: Element | SysMLElement,
+        resolve_libraries: bool = False,
     ) -> MappedElement:
         """
         Map a JSON element to a Python object and return unresolved references.
@@ -49,6 +50,9 @@ class Mapper(ABC):
             Data.
         mapped_element : Element | SysMLElement
             Existing element.
+        resolve_libraries : bool, default: False
+            When ``True``, library elements keep their unresolved references so their
+            contents are resolved and mapped; otherwise those references are dropped.
 
         Returns
         -------

--- a/src/ansys/sam/sysml2/builder/mapper/scripting_mapper.py
+++ b/src/ansys/sam/sysml2/builder/mapper/scripting_mapper.py
@@ -38,7 +38,12 @@ class ScriptingMapper(Mapper):
 
     class_cache = {}
 
-    def map(self, json_element: dict, mapped_element: SysMLElement) -> MappedElement:
+    def map(
+        self,
+        json_element: dict,
+        mapped_element: SysMLElement,
+        resolve_libraries: bool = False,
+    ) -> MappedElement:
         """
         Map the JSON into a python element.
 
@@ -48,6 +53,9 @@ class ScriptingMapper(Mapper):
             Element data.
         mapped_element : SysMLElement
             Existing element.
+        resolve_libraries : bool, default: False
+            When ``True``, keep library elements' unresolved references so their contents
+            are resolved and mapped.
 
         Returns
         -------
@@ -57,9 +65,14 @@ class ScriptingMapper(Mapper):
         if TYPE_KEY not in json_element:
             raise InvalidProjectJSONMapperException("Not valid sysml element data")
 
-        return self.__build_element(json_element, mapped_element)
+        return self.__build_element(json_element, mapped_element, resolve_libraries)
 
-    def __build_element(self, data: dict, element: SysMLElement | None) -> MappedElement:
+    def __build_element(
+        self,
+        data: dict,
+        element: SysMLElement | None,
+        resolve_libraries: bool = False,
+    ) -> MappedElement:
         """
         Map element data to python object.
 
@@ -69,6 +82,9 @@ class ScriptingMapper(Mapper):
             Element data.
         element : SysMLElement
             Existing element.
+        resolve_libraries : bool, default: False
+            When ``True``, keep library elements' unresolved references so their contents
+            are resolved and mapped.
 
         Returns
         -------
@@ -82,7 +98,7 @@ class ScriptingMapper(Mapper):
             if not k.startswith("@"):
                 unresolved_fields.extend(self.__add_fields(element, k, v))
         self.__update_element_definition(data, element)
-        if getattr(element, "_isLibraryElement", False):
+        if not resolve_libraries and getattr(element, "_isLibraryElement", False):
             unresolved_fields = []
         return MappedElement(element, unresolved_fields)
 

--- a/src/ansys/sam/sysml2/builder/mapper/sysml_mapper.py
+++ b/src/ansys/sam/sysml2/builder/mapper/sysml_mapper.py
@@ -38,7 +38,12 @@ class SysMLMapper(Mapper):
 
     class_cache = {}
 
-    def map(self, json_element: dict, mapped_element: Element) -> MappedElement:
+    def map(
+        self,
+        json_element: dict,
+        mapped_element: Element,
+        resolve_libraries: bool = False,
+    ) -> MappedElement:
         """
         Map the JSON into a python element.
 
@@ -48,6 +53,9 @@ class SysMLMapper(Mapper):
             Element data.
         mapped_element : Element
             Existing element.
+        resolve_libraries : bool, default: False
+            When ``True``, keep library elements' unresolved references so their contents
+            are resolved and mapped.
 
         Returns
         -------
@@ -57,9 +65,14 @@ class SysMLMapper(Mapper):
         if TYPE_KEY not in json_element:
             raise InvalidProjectJSONMapperException("Not valid sysml element data")
 
-        return self.__build_element(json_element, mapped_element)
+        return self.__build_element(json_element, mapped_element, resolve_libraries)
 
-    def __build_element(self, data: dict, element: Element | None) -> MappedElement:
+    def __build_element(
+        self,
+        data: dict,
+        element: Element | None,
+        resolve_libraries: bool = False,
+    ) -> MappedElement:
         """
         Map element data to python object.
 
@@ -69,6 +82,9 @@ class SysMLMapper(Mapper):
             Element data.
         element : Element
             Existing element.
+        resolve_libraries : bool, default: False
+            When ``True``, keep library elements' unresolved references so their contents
+            are resolved and mapped.
 
         Returns
         -------
@@ -82,7 +98,7 @@ class SysMLMapper(Mapper):
         for k, v in data.items():
             if not k.startswith("@"):
                 unresolved_fields.extend(self.__add_fields(element, k, v))
-        if getattr(element, "is_library_element", False):
+        if not resolve_libraries and getattr(element, "is_library_element", False):
             unresolved_fields = []
         return MappedElement(element, unresolved_fields)
 

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -66,17 +66,51 @@ class SysML2ProjectBuilder:
         """
         self._connector = connector
 
-    def build_sysml_project(self, project_id: str) -> Project:
-        """Call the API with the specified project ID and build the SysML project from JSON."""
+    def build_sysml_project(self, project_id: str, resolve_libraries: bool = False) -> Project:
+        """
+        Call the API with the specified project ID and build the SysML project from JSON.
+
+        Parameters
+        ----------
+        project_id : str
+            ID of the project to build.
+        resolve_libraries : bool, default: False
+            When ``True``, keep library elements' references so their contents are resolved
+            and mapped during the build.
+
+        Returns
+        -------
+        Project
+            The fully built SysML project.
+        """
         project_info = self._connector.get_project_by_id(project_id)
         project = ProjectImpl(project_id, project_info["name"])
+        project._resolve_libraries = resolve_libraries
         self.__build_project(project)
         return project
 
-    def build_scripting_project(self, project_id: str) -> ScriptingProject:
-        """Call the API with the specified project ID and build the scripting project from JSON."""
+    def build_scripting_project(
+        self, project_id: str, resolve_libraries: bool = False
+    ) -> ScriptingProject:
+        """
+        Call the API with the specified project ID and build the scripting project from JSON.
+
+        Parameters
+        ----------
+        project_id : str
+            ID of the project to build.
+        resolve_libraries : bool, default: False
+            When ``True``, keep library elements' references so their contents are resolved
+            and mapped during the build.
+
+        Returns
+        -------
+        ScriptingProject
+            The fully built scripting project.
+        """
         project_info = self._connector.get_project_by_id(project_id)
         project = ScriptingProjectImpl(project_id, project_info["name"])
+        project._resolve_libraries = resolve_libraries
         self.__build_project(project)
         return project
 
@@ -171,9 +205,10 @@ class SysML2ProjectBuilder:
         """
         unresolved_fields = []
         mapper = self._get_mapper(project)
+        resolve_libraries = getattr(project, "_resolve_libraries", False)
         for element in elements:
             existing_element = project.find_element_by_id(element["@id"])
-            mapped_element = mapper.map(element, existing_element)
+            mapped_element = mapper.map(element, existing_element, resolve_libraries)
             project.add_element(mapped_element.get_element())
             unresolved_fields.extend(mapped_element.get_unresolved_fields())
         project.update_unresolved_fields(unresolved_fields)
@@ -303,6 +338,7 @@ class SysML2ProjectBuilder:
             Project instance to reload.
         """
         modification_observer.stop()
+        project._resolve_libraries = False  # libraries are static; never re-resolve on reload
         self._build_project_element(project)
         self._resolve_inherited_link(project)
         self._add_write_access(project)

--- a/src/ansys/sam/sysml2/builder/sysml2_project_manager.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_manager.py
@@ -52,19 +52,55 @@ class SysML2ProjectManager:
         """
         return self._connector.get_projects()
 
-    def get_sysml_project(self, project_id: str) -> Project:
-        """Get a SysML project with its ID from the API and map it in a Python object."""
+    def get_sysml_project(self, project_id: str, resolve_libraries: bool = False) -> Project:
+        """
+        Get a SysML project with its ID from the API and map it in a Python object.
+
+        Parameters
+        ----------
+        project_id : str
+            ID of the project to load.
+        resolve_libraries : bool, default: False
+            When ``True``, library element contents are resolved and mapped so they can be
+            navigated. Only applied on first load; a cached project is returned as-is.
+
+        Returns
+        -------
+        Project
+            The requested project, built from the API or returned from cache.
+        """
         project = self._sysml_projects.get(project_id)
         if project is None:
-            project = SysML2ProjectBuilder(self._connector).build_sysml_project(project_id)
+            project = SysML2ProjectBuilder(self._connector).build_sysml_project(
+                project_id, resolve_libraries
+            )
             self._sysml_projects[project_id] = project
         return project
 
-    def get_scripting_project(self, project_id: str) -> ScriptingProject:
-        """Get a scripting project with its ID from the API and map it in a Python object."""
+    def get_scripting_project(
+        self, project_id: str, resolve_libraries: bool = False
+    ) -> ScriptingProject:
+        """
+        Get a scripting project with its ID from the API and map it in a Python object.
+
+        Parameters
+        ----------
+        project_id : str
+            ID of the project to load.
+        resolve_libraries : bool, default: False
+            When ``True``, library element contents are resolved and mapped so they can be
+            navigated. Only applied on first load; a cached project is returned as-is.
+
+        Returns
+        -------
+        ScriptingProject
+            The requested project, built from the API or returned from cache.
+        """
         project = self._scripting_projects.get(project_id)
         if project is None:
-            project = SysML2ProjectBuilder(self._connector).build_scripting_project(project_id)
+            project = SysML2ProjectBuilder(self._connector).build_scripting_project(
+                project_id, resolve_libraries
+            )
             self._scripting_projects[project_id] = project
         return project
 

--- a/src/ansys/sam/sysml2/tools/ansys_project.py
+++ b/src/ansys/sam/sysml2/tools/ansys_project.py
@@ -47,6 +47,7 @@ class AnsysProject:
         organization_id: str,
         project_id: str,
         use_ssl: bool = True,
+        resolve_libraries: bool = False,
     ) -> None:
         """
         Initialize the AnsysProject with connection parameters.
@@ -63,10 +64,13 @@ class AnsysProject:
             Unique identifier of the project to manage.
         use_ssl : bool, optional
             Whether to use SSL/TLS for connections. Default is True.
+        resolve_libraries : bool, optional
+            When True, resolve and map library element contents so they can be navigated.
+            Default is False.
         """
         self._project_id = project_id
         self.__diagrams_available = False
-        self._initialize_components(server_url, token, organization_id, use_ssl)
+        self._initialize_components(server_url, token, organization_id, use_ssl, resolve_libraries)
 
     def _initialize_components(
         self,
@@ -74,6 +78,7 @@ class AnsysProject:
         token: str,
         organization_id: str,
         use_ssl: bool = True,
+        resolve_libraries: bool = False,
     ) -> None:
         """Initialize all internal components and establish connections."""
         sysml2_connector = AnsysSysML2APIConnector(
@@ -87,7 +92,7 @@ class AnsysProject:
             server_url=server_url, token=token, use_ssl=use_ssl
         )
 
-        project = self._get_project(sysml2_connector)
+        project = self._get_project(sysml2_connector, resolve_libraries)
 
         for attr_name, attr_value in project.__dict__.items():
             if attr_name.startswith("_"):
@@ -97,8 +102,26 @@ class AnsysProject:
 
         self._initialize_diagram_capabilities()
 
-    def _get_project(self, sysml2_connector: AnsysSysML2APIConnector):
-        """Retrieve the correct project type."""
+    def _get_project(
+        self,
+        sysml2_connector: AnsysSysML2APIConnector,
+        resolve_libraries: bool = False,
+    ):
+        """
+        Retrieve the correct project type.
+
+        Parameters
+        ----------
+        sysml2_connector : AnsysSysML2APIConnector
+            Connector used to load the project.
+        resolve_libraries : bool, default: False
+            When ``True``, resolve and map library element contents so they can be navigated.
+
+        Returns
+        -------
+        Project or ScriptingProject
+            The loaded project, provided by the concrete subclass.
+        """
         raise NotImplementedError
 
     def _initialize_diagram_capabilities(self) -> None:

--- a/src/ansys/sam/sysml2/tools/ansys_scripting_project.py
+++ b/src/ansys/sam/sysml2/tools/ansys_scripting_project.py
@@ -30,8 +30,26 @@ from ansys.sam.sysml2.tools.ansys_project import AnsysProject
 class AnsysScriptingProject(AnsysProject, ScriptingProjectImpl):
     """Complete Ansys Scripting project implementation with integrated capabilities."""
 
-    def _get_project(self, sysml2_connector: AnsysSysML2APIConnector) -> ScriptingProject:
-        """Load a scripting project."""
+    def _get_project(
+        self,
+        sysml2_connector: AnsysSysML2APIConnector,
+        resolve_libraries: bool = False,
+    ) -> ScriptingProject:
+        """
+        Load a scripting project.
+
+        Parameters
+        ----------
+        sysml2_connector : AnsysSysML2APIConnector
+            Connector used to load the project.
+        resolve_libraries : bool, default: False
+            When ``True``, resolve and map library element contents so they can be navigated.
+
+        Returns
+        -------
+        ScriptingProject
+            The loaded scripting project.
+        """
         project_manager = SysML2ProjectManager(connector=sysml2_connector)
-        project = project_manager.get_scripting_project(self._project_id)
+        project = project_manager.get_scripting_project(self._project_id, resolve_libraries)
         return project

--- a/src/ansys/sam/sysml2/tools/ansys_sysml2_project.py
+++ b/src/ansys/sam/sysml2/tools/ansys_sysml2_project.py
@@ -30,8 +30,26 @@ from ansys.sam.sysml2.tools.ansys_project import AnsysProject
 class AnsysSysML2Project(AnsysProject, ProjectImpl):
     """Complete Ansys SysML project implementation with integrated capabilities."""
 
-    def _get_project(self, sysml2_connector: AnsysSysML2APIConnector) -> Project:
-        """Load a SysML project."""
+    def _get_project(
+        self,
+        sysml2_connector: AnsysSysML2APIConnector,
+        resolve_libraries: bool = False,
+    ) -> Project:
+        """
+        Load a SysML project.
+
+        Parameters
+        ----------
+        sysml2_connector : AnsysSysML2APIConnector
+            Connector used to load the project.
+        resolve_libraries : bool, default: False
+            When ``True``, resolve and map library element contents so they can be navigated.
+
+        Returns
+        -------
+        Project
+            The loaded SysML project.
+        """
         project_manager = SysML2ProjectManager(connector=sysml2_connector)
-        project = project_manager.get_sysml_project(self._project_id)
+        project = project_manager.get_sysml_project(self._project_id, resolve_libraries)
         return project


### PR DESCRIPTION
## Summary

By default, elements that belong to imported libraries are mapped but their
references are dropped, so their contents can't be navigated. This adds an
opt-in `resolve_libraries` flag that, when enabled, keeps those references so
library element contents are fully resolved and mapped.

The flag is threaded from the public entry points down to the mappers and
defaults to `False`, so existing behavior is unchanged unless a caller opts in.

## Behavior

- `resolve_libraries=False` (default): unchanged — library references dropped.
- `resolve_libraries=True`: library element references are retained, resolved,
  and mapped so they can be navigated. Applied on first load only; a cached
  project is returned as-is.
- `reload_project` does not re-resolve libraries.