### PR TITLE
fix: hide private backing fields from static element autocomplete

### DIFF
--- a/doc/changelog.d/214.fixed.md
+++ b/doc/changelog.d/214.fixed.md
@@ -1,0 +1,1 @@
+Hide private backing fields from static element autocomplete

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -45,8 +45,8 @@ class EObject:
         self._element_hash_map = {}
 
     def __dir__(self):
-        """Children are reachable via get(), not dot; hide the internal proxy cache."""
-        names = [a for a in super().__dir__() if a != "_proxy_cache" and not a.startswith("#")]
+        """Expose the public SysML API only: hide single-underscore backing fields."""
+        names = [a for a in super().__dir__() if not (a.startswith("_") and not a.startswith("__"))]
         if not ValueHelper.is_value_capable(self):
             names = [a for a in names if a not in ("get_value", "set_value", "parse_and_set_value")]
         if not getattr(self, "source", None):

--- a/tests/unit/sam/sysml2/meta_model/test_e_object.py
+++ b/tests/unit/sam/sysml2/meta_model/test_e_object.py
@@ -162,3 +162,39 @@ class TestEObjectDir:
 
         assert "get_target" in dir(element)
         assert "get_source" not in dir(element)
+
+
+class TestEObjectDirPublicOnly:
+    """dir() exposes the public SysML API only, hiding single-underscore backing fields."""
+
+    def test_public_properties_listed(self):
+        element = PartUsage("element_id")
+
+        listing = dir(element)
+        assert "declared_name" in listing
+        assert "name" in listing
+        assert "id" in listing
+        assert "owned_element" in listing
+
+    def test_single_underscore_backing_fields_hidden(self):
+        element = PartUsage("element_id")
+
+        listing = dir(element)
+        assert "_declared_name" not in listing
+        assert "_name" not in listing
+        assert "_owner" not in listing
+        assert "_id" not in listing
+        assert "_proxy_cache" not in listing
+
+    def test_no_single_underscore_names_at_all(self):
+        element = PartUsage("element_id")
+
+        private = [
+            a for a in dir(element) if a.startswith("_") and not a.startswith("__")
+        ]
+        assert private == []
+
+    def test_dunders_still_listed(self):
+        element = PartUsage("element_id")
+
+        assert "__class__" in dir(element)


### PR DESCRIPTION
Restore and enhance the pre-align-mm Jupyter autocomplete behavior for the static
(SysML) approach: only public members show up on an element, not the
single-underscore metamodel backing fields.

Issue #183 and #213