### PR TITLE
fix: add enum support

### DIFF
--- a/.codespellignorewords
+++ b/.codespellignorewords
@@ -1,2 +1,3 @@
 Synopsys
 synopsys
+inout

--- a/doc/changelog.d/237.fixed.md
+++ b/doc/changelog.d/237.fixed.md
@@ -1,0 +1,1 @@
+Add enum support

--- a/src/ansys/sam/sysml2/builder/mapper/mapper.py
+++ b/src/ansys/sam/sysml2/builder/mapper/mapper.py
@@ -29,6 +29,25 @@ from ansys.sam.sysml2.classes.sysml_element import SysMLElement
 from ansys.sam.sysml2.classes.unresolved_field import UnresolvedField
 from ansys.sam.sysml2.data_structures.observed_list import ObservedList
 from ansys.sam.sysml2.meta_model.element import Element
+from ansys.sam.sysml2.meta_model.feature_direction_kind import FeatureDirectionKind
+from ansys.sam.sysml2.meta_model.portion_kind import PortionKind
+from ansys.sam.sysml2.meta_model.requirement_constraint_kind import RequirementConstraintKind
+from ansys.sam.sysml2.meta_model.state_subaction_kind import StateSubactionKind
+from ansys.sam.sysml2.meta_model.transition_feature_kind import TransitionFeatureKind
+from ansys.sam.sysml2.meta_model.trigger_kind import TriggerKind
+from ansys.sam.sysml2.meta_model.visibility_kind import VisibilityKind
+
+dict_of_classes = {
+    "direction": FeatureDirectionKind,
+    "portionKind": PortionKind,
+    "visibility": VisibilityKind,
+    "kind": {
+        "RequirementConstraintMembership": RequirementConstraintKind,
+        "StateSubactionMembership": StateSubactionKind,
+        "TransitionFeatureMembership": TransitionFeatureKind,
+        "TriggerInvocationExpression": TriggerKind,
+    },
+}
 
 
 class Mapper(ABC):
@@ -59,6 +78,37 @@ class Mapper(ABC):
         MappedElement
             Mapper element.
         """
+
+    def _convert_enum(self, element, field_name: str, field_values):
+        """Translate an API string into its Kind enum member.
+
+        For ``kind`` (used by several element types) the target enum depends on
+        the element type; other enum fields map directly by name.
+
+        Parameters
+        ----------
+        element : Element | SysMLElement
+            Destination element, used to disambiguate ``kind``.
+        field_name : str
+            Raw JSON field name.
+        field_values : Any
+            Field value; only ``str`` values are converted.
+
+        Returns
+        -------
+        Any
+            The matching enum member, or the original value when the field is not
+            an enum field or the literal is unknown.
+        """
+        enum_cls = dict_of_classes.get(field_name)
+        if isinstance(enum_cls, dict):
+            enum_cls = enum_cls.get(type(element).__name__)
+        if enum_cls is None or not isinstance(field_values, str):
+            return field_values
+        member = getattr(enum_cls, field_values.upper(), None)
+        if member is None:
+            print(f"Warning: '{field_values}' is not a valid {enum_cls.__name__}")
+        return member or field_values
 
     def _add_default_field(self, element, field_name: str, field_value) -> list:
         """Set a scalar field on the element.

--- a/src/ansys/sam/sysml2/builder/mapper/scripting_mapper.py
+++ b/src/ansys/sam/sysml2/builder/mapper/scripting_mapper.py
@@ -94,10 +94,10 @@ class ScriptingMapper(Mapper):
         unresolved_fields = []
         if element is None:
             element = SysMLElement(element_id=data["@id"])
+        self.__update_element_definition(data, element)
         for k, v in data.items():
             if not k.startswith("@"):
                 unresolved_fields.extend(self.__add_fields(element, k, v))
-        self.__update_element_definition(data, element)
         if not resolve_libraries and getattr(element, "_isLibraryElement", False):
             unresolved_fields = []
         return MappedElement(element, unresolved_fields)
@@ -143,6 +143,7 @@ class ScriptingMapper(Mapper):
         List[UnresolvedField]
             List of all unresolved fields.
         """
+        field_values = self._convert_enum(element, field_name, field_values)
         field_name = "_" + field_name
         if isinstance(field_values, list):
             return self._add_list_to_field(element, field_name, field_values)

--- a/src/ansys/sam/sysml2/builder/mapper/sysml_mapper.py
+++ b/src/ansys/sam/sysml2/builder/mapper/sysml_mapper.py
@@ -127,6 +127,7 @@ class SysMLMapper(Mapper):
         """
         from ansys.sam.sysml2.tools.name_utils import NameUtils
 
+        field_values = self._convert_enum(element, field_name, field_values)
         field_name = "_" + NameUtils.to_snake_case(field_name)
         if isinstance(field_values, list):
             return self._add_list_to_field(element, field_name, field_values)

--- a/src/ansys/sam/sysml2/dto/commit/data_version.py
+++ b/src/ansys/sam/sysml2/dto/commit/data_version.py
@@ -48,6 +48,8 @@ class DataVersion:
         value: Any
             Value of the change.
         """
+        from enum import Enum
+
         from ansys.sam.sysml2.classes.sysml_element import SysMLElement
         from ansys.sam.sysml2.data_structures.observed_list import ObservedList
         from ansys.sam.sysml2.meta_model.e_object import EObject
@@ -70,6 +72,8 @@ class DataVersion:
                 )
                 for x in value
             ]
+        elif isinstance(value, Enum):
+            self.payload[key] = value.value
         else:
             self.payload[key] = value
 

--- a/src/ansys/sam/sysml2/meta_model/feature_direction_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/feature_direction_kind.py
@@ -22,75 +22,12 @@
 
 """Generated feature direction kind class from metamodel."""
 
-from __future__ import annotations
+from enum import Enum
 
 
-class FeatureDirectionKind:
+class FeatureDirectionKind(str, Enum):
     """Java class 'com.ansys.metamodel.sysml2.FeatureDirectionKind'."""
 
-    IN: "FeatureDirectionKind"
-    INOUT: "FeatureDirectionKind"
-    INOUT_VALUE: int
-    IN_VALUE: int
-    OUT: "FeatureDirectionKind"
-    OUT_VALUE: int
-    VALUES: list
-    VALUES_ARRAY: "FeatureDirectionKind"
-    literal: str
-    name: str
-    value: int
-
-    def __init__(self):
-        """Construct new instance."""
-        self._by_name = None
-        self._literal = ""
-        self._name = ""
-        self._value = 0
-
-    @property
-    def by_name(self) -> "FeatureDirectionKind":  # noqa: F821
-        """
-        Get the by name property.
-
-        Returns
-        -------
-        "FeatureDirectionKind"
-            Value of property by name.
-        """
-        return self._by_name
-
-    @property
-    def literal(self) -> str:  # noqa: F821
-        """
-        Get the literal property.
-
-        Returns
-        -------
-        str
-            Value of property literal.
-        """
-        return self._literal
-
-    @property
-    def name(self) -> str:  # noqa: F821
-        """
-        Get the name property.
-
-        Returns
-        -------
-        str
-            Value of property name.
-        """
-        return self._name
-
-    @property
-    def value(self) -> int:
-        """
-        Get the value property.
-
-        Returns
-        -------
-        int
-            Value of property value.
-        """
-        return self._value
+    IN = "in"
+    INOUT = "inout"
+    OUT = "out"

--- a/src/ansys/sam/sysml2/meta_model/feature_direction_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/feature_direction_kind.py
@@ -25,7 +25,7 @@
 from enum import Enum
 
 
-class FeatureDirectionKind(str, Enum):
+class FeatureDirectionKind(Enum):
     """Java class 'com.ansys.metamodel.sysml2.FeatureDirectionKind'."""
 
     IN = "in"

--- a/src/ansys/sam/sysml2/meta_model/portion_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/portion_kind.py
@@ -25,7 +25,7 @@
 from enum import Enum
 
 
-class PortionKind(str, Enum):
+class PortionKind(Enum):
     """Java class 'com.ansys.metamodel.sysml2.PortionKind'."""
 
     TIMESLICE = "timeslice"

--- a/src/ansys/sam/sysml2/meta_model/portion_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/portion_kind.py
@@ -22,73 +22,11 @@
 
 """Generated portion kind class from metamodel."""
 
-from __future__ import annotations
+from enum import Enum
 
 
-class PortionKind:
+class PortionKind(str, Enum):
     """Java class 'com.ansys.metamodel.sysml2.PortionKind'."""
 
-    SNAPSHOT: "PortionKind"
-    SNAPSHOT_VALUE: int
-    TIMESLICE: "PortionKind"
-    TIMESLICE_VALUE: int
-    VALUES: list
-    VALUES_ARRAY: "PortionKind"
-    literal: str
-    name: str
-    value: int
-
-    def __init__(self):
-        """Construct new instance."""
-        self._by_name = None
-        self._literal = ""
-        self._name = ""
-        self._value = 0
-
-    @property
-    def by_name(self) -> "PortionKind":  # noqa: F821
-        """
-        Get the by name property.
-
-        Returns
-        -------
-        "PortionKind"
-            Value of property by name.
-        """
-        return self._by_name
-
-    @property
-    def literal(self) -> str:  # noqa: F821
-        """
-        Get the literal property.
-
-        Returns
-        -------
-        str
-            Value of property literal.
-        """
-        return self._literal
-
-    @property
-    def name(self) -> str:  # noqa: F821
-        """
-        Get the name property.
-
-        Returns
-        -------
-        str
-            Value of property name.
-        """
-        return self._name
-
-    @property
-    def value(self) -> int:
-        """
-        Get the value property.
-
-        Returns
-        -------
-        int
-            Value of property value.
-        """
-        return self._value
+    TIMESLICE = "timeslice"
+    SNAPSHOT = "snapshot"

--- a/src/ansys/sam/sysml2/meta_model/requirement_constraint_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/requirement_constraint_kind.py
@@ -25,7 +25,7 @@
 from enum import Enum
 
 
-class RequirementConstraintKind(str, Enum):
+class RequirementConstraintKind(Enum):
     """Java class 'com.ansys.metamodel.sysml2.RequirementConstraintKind'."""
 
     ASSUMPTION = "assumption"

--- a/src/ansys/sam/sysml2/meta_model/requirement_constraint_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/requirement_constraint_kind.py
@@ -22,73 +22,11 @@
 
 """Generated requirement constraint kind class from metamodel."""
 
-from __future__ import annotations
+from enum import Enum
 
 
-class RequirementConstraintKind:
+class RequirementConstraintKind(str, Enum):
     """Java class 'com.ansys.metamodel.sysml2.RequirementConstraintKind'."""
 
-    ASSUMPTION: "RequirementConstraintKind"
-    ASSUMPTION_VALUE: int
-    REQUIREMENT: "RequirementConstraintKind"
-    REQUIREMENT_VALUE: int
-    VALUES: list
-    VALUES_ARRAY: "RequirementConstraintKind"
-    literal: str
-    name: str
-    value: int
-
-    def __init__(self):
-        """Construct new instance."""
-        self._by_name = None
-        self._literal = ""
-        self._name = ""
-        self._value = 0
-
-    @property
-    def by_name(self) -> "RequirementConstraintKind":  # noqa: F821
-        """
-        Get the by name property.
-
-        Returns
-        -------
-        "RequirementConstraintKind"
-            Value of property by name.
-        """
-        return self._by_name
-
-    @property
-    def literal(self) -> str:  # noqa: F821
-        """
-        Get the literal property.
-
-        Returns
-        -------
-        str
-            Value of property literal.
-        """
-        return self._literal
-
-    @property
-    def name(self) -> str:  # noqa: F821
-        """
-        Get the name property.
-
-        Returns
-        -------
-        str
-            Value of property name.
-        """
-        return self._name
-
-    @property
-    def value(self) -> int:
-        """
-        Get the value property.
-
-        Returns
-        -------
-        int
-            Value of property value.
-        """
-        return self._value
+    ASSUMPTION = "assumption"
+    REQUIREMENT = "requirement"

--- a/src/ansys/sam/sysml2/meta_model/state_subaction_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/state_subaction_kind.py
@@ -25,7 +25,7 @@
 from enum import Enum
 
 
-class StateSubactionKind(str, Enum):
+class StateSubactionKind(Enum):
     """Java class 'com.ansys.metamodel.sysml2.StateSubactionKind'."""
 
     ENTRY = "entry"

--- a/src/ansys/sam/sysml2/meta_model/state_subaction_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/state_subaction_kind.py
@@ -22,75 +22,12 @@
 
 """Generated state subaction kind class from metamodel."""
 
-from __future__ import annotations
+from enum import Enum
 
 
-class StateSubactionKind:
+class StateSubactionKind(str, Enum):
     """Java class 'com.ansys.metamodel.sysml2.StateSubactionKind'."""
 
-    DO: "StateSubactionKind"
-    DO_VALUE: int
-    ENTRY: "StateSubactionKind"
-    ENTRY_VALUE: int
-    EXIT: "StateSubactionKind"
-    EXIT_VALUE: int
-    VALUES: list
-    VALUES_ARRAY: "StateSubactionKind"
-    literal: str
-    name: str
-    value: int
-
-    def __init__(self):
-        """Construct new instance."""
-        self._by_name = None
-        self._literal = ""
-        self._name = ""
-        self._value = 0
-
-    @property
-    def by_name(self) -> "StateSubactionKind":  # noqa: F821
-        """
-        Get the by name property.
-
-        Returns
-        -------
-        "StateSubactionKind"
-            Value of property by name.
-        """
-        return self._by_name
-
-    @property
-    def literal(self) -> str:  # noqa: F821
-        """
-        Get the literal property.
-
-        Returns
-        -------
-        str
-            Value of property literal.
-        """
-        return self._literal
-
-    @property
-    def name(self) -> str:  # noqa: F821
-        """
-        Get the name property.
-
-        Returns
-        -------
-        str
-            Value of property name.
-        """
-        return self._name
-
-    @property
-    def value(self) -> int:
-        """
-        Get the value property.
-
-        Returns
-        -------
-        int
-            Value of property value.
-        """
-        return self._value
+    ENTRY = "entry"
+    DO = "do"
+    EXIT = "exit"

--- a/src/ansys/sam/sysml2/meta_model/transition_feature_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/transition_feature_kind.py
@@ -22,75 +22,12 @@
 
 """Generated transition feature kind class from metamodel."""
 
-from __future__ import annotations
+from enum import Enum
 
 
-class TransitionFeatureKind:
+class TransitionFeatureKind(str, Enum):
     """Java class 'com.ansys.metamodel.sysml2.TransitionFeatureKind'."""
 
-    EFFECT: "TransitionFeatureKind"
-    EFFECT_VALUE: int
-    GUARD: "TransitionFeatureKind"
-    GUARD_VALUE: int
-    TRIGGER: "TransitionFeatureKind"
-    TRIGGER_VALUE: int
-    VALUES: list
-    VALUES_ARRAY: "TransitionFeatureKind"
-    literal: str
-    name: str
-    value: int
-
-    def __init__(self):
-        """Construct new instance."""
-        self._by_name = None
-        self._literal = ""
-        self._name = ""
-        self._value = 0
-
-    @property
-    def by_name(self) -> "TransitionFeatureKind":  # noqa: F821
-        """
-        Get the by name property.
-
-        Returns
-        -------
-        "TransitionFeatureKind"
-            Value of property by name.
-        """
-        return self._by_name
-
-    @property
-    def literal(self) -> str:  # noqa: F821
-        """
-        Get the literal property.
-
-        Returns
-        -------
-        str
-            Value of property literal.
-        """
-        return self._literal
-
-    @property
-    def name(self) -> str:  # noqa: F821
-        """
-        Get the name property.
-
-        Returns
-        -------
-        str
-            Value of property name.
-        """
-        return self._name
-
-    @property
-    def value(self) -> int:
-        """
-        Get the value property.
-
-        Returns
-        -------
-        int
-            Value of property value.
-        """
-        return self._value
+    TRIGGER = "trigger"
+    GUARD = "guard"
+    EFFECT = "effect"

--- a/src/ansys/sam/sysml2/meta_model/transition_feature_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/transition_feature_kind.py
@@ -25,7 +25,7 @@
 from enum import Enum
 
 
-class TransitionFeatureKind(str, Enum):
+class TransitionFeatureKind(Enum):
     """Java class 'com.ansys.metamodel.sysml2.TransitionFeatureKind'."""
 
     TRIGGER = "trigger"

--- a/src/ansys/sam/sysml2/meta_model/trigger_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/trigger_kind.py
@@ -22,75 +22,12 @@
 
 """Generated trigger kind class from metamodel."""
 
-from __future__ import annotations
+from enum import Enum
 
 
-class TriggerKind:
+class TriggerKind(str, Enum):
     """Java class 'com.ansys.metamodel.sysml2.TriggerKind'."""
 
-    AFTER: "TriggerKind"
-    AFTER_VALUE: int
-    AT: "TriggerKind"
-    AT_VALUE: int
-    VALUES: list
-    VALUES_ARRAY: "TriggerKind"
-    WHEN: "TriggerKind"
-    WHEN_VALUE: int
-    literal: str
-    name: str
-    value: int
-
-    def __init__(self):
-        """Construct new instance."""
-        self._by_name = None
-        self._literal = ""
-        self._name = ""
-        self._value = 0
-
-    @property
-    def by_name(self) -> "TriggerKind":  # noqa: F821
-        """
-        Get the by name property.
-
-        Returns
-        -------
-        "TriggerKind"
-            Value of property by name.
-        """
-        return self._by_name
-
-    @property
-    def literal(self) -> str:  # noqa: F821
-        """
-        Get the literal property.
-
-        Returns
-        -------
-        str
-            Value of property literal.
-        """
-        return self._literal
-
-    @property
-    def name(self) -> str:  # noqa: F821
-        """
-        Get the name property.
-
-        Returns
-        -------
-        str
-            Value of property name.
-        """
-        return self._name
-
-    @property
-    def value(self) -> int:
-        """
-        Get the value property.
-
-        Returns
-        -------
-        int
-            Value of property value.
-        """
-        return self._value
+    WHEN = "when"
+    AT = "at"
+    AFTER = "after"

--- a/src/ansys/sam/sysml2/meta_model/trigger_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/trigger_kind.py
@@ -25,7 +25,7 @@
 from enum import Enum
 
 
-class TriggerKind(str, Enum):
+class TriggerKind(Enum):
     """Java class 'com.ansys.metamodel.sysml2.TriggerKind'."""
 
     WHEN = "when"

--- a/src/ansys/sam/sysml2/meta_model/type_.py
+++ b/src/ansys/sam/sysml2/meta_model/type_.py
@@ -48,9 +48,13 @@ class Type(Namespace):
         self._directed_feature = ObservedList(self, "directed_feature")
         self._end_feature = ObservedList(self, "end_feature")
         self._feature = ObservedList(self, "feature")
+        self._feature_exclude_implied = ObservedList(self, "feature_exclude_implied")
         self._feature_membership = ObservedList(self, "feature_membership")
         self._inherited_feature = ObservedList(self, "inherited_feature")
         self._inherited_membership = ObservedList(self, "inherited_membership")
+        self._inherited_membership_exclude_implied = ObservedList(
+            self, "inherited_membership_exclude_implied"
+        )
         self._input = ObservedList(self, "input")
         self._intersecting_type = ObservedList(self, "intersecting_type")
         self._multiplicity = None
@@ -147,6 +151,18 @@ class Type(Namespace):
         return self._feature
 
     @property
+    def feature_exclude_implied(self) -> list["Feature"]:  # noqa: F821
+        """
+        Get the feature exclude implied property.
+
+        Returns
+        -------
+        list["Feature"]
+            Value of property feature exclude implied.
+        """
+        return self._feature_exclude_implied
+
+    @property
     def feature_membership(self) -> list["FeatureMembership"]:  # noqa: F821
         """
         Get the feature membership property.
@@ -181,6 +197,18 @@ class Type(Namespace):
             Value of property inherited membership.
         """
         return self._inherited_membership
+
+    @property
+    def inherited_membership_exclude_implied(self) -> list["Membership"]:  # noqa: F821
+        """
+        Get the inherited membership exclude implied property.
+
+        Returns
+        -------
+        list["Membership"]
+            Value of property inherited membership exclude implied.
+        """
+        return self._inherited_membership_exclude_implied
 
     @property
     def input(self) -> list["Feature"]:  # noqa: F821

--- a/src/ansys/sam/sysml2/meta_model/visibility_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/visibility_kind.py
@@ -25,7 +25,7 @@
 from enum import Enum
 
 
-class VisibilityKind(str, Enum):
+class VisibilityKind(Enum):
     """Java class 'com.ansys.metamodel.sysml2.VisibilityKind'."""
 
     PRIVATE = "private"

--- a/src/ansys/sam/sysml2/meta_model/visibility_kind.py
+++ b/src/ansys/sam/sysml2/meta_model/visibility_kind.py
@@ -22,75 +22,12 @@
 
 """Generated visibility kind class from metamodel."""
 
-from __future__ import annotations
+from enum import Enum
 
 
-class VisibilityKind:
+class VisibilityKind(str, Enum):
     """Java class 'com.ansys.metamodel.sysml2.VisibilityKind'."""
 
-    PRIVATE: "VisibilityKind"
-    PRIVATE_VALUE: int
-    PROTECTED: "VisibilityKind"
-    PROTECTED_VALUE: int
-    PUBLIC: "VisibilityKind"
-    PUBLIC_VALUE: int
-    VALUES: list
-    VALUES_ARRAY: "VisibilityKind"
-    literal: str
-    name: str
-    value: int
-
-    def __init__(self):
-        """Construct new instance."""
-        self._by_name = None
-        self._literal = ""
-        self._name = ""
-        self._value = 0
-
-    @property
-    def by_name(self) -> "VisibilityKind":  # noqa: F821
-        """
-        Get the by name property.
-
-        Returns
-        -------
-        "VisibilityKind"
-            Value of property by name.
-        """
-        return self._by_name
-
-    @property
-    def literal(self) -> str:  # noqa: F821
-        """
-        Get the literal property.
-
-        Returns
-        -------
-        str
-            Value of property literal.
-        """
-        return self._literal
-
-    @property
-    def name(self) -> str:  # noqa: F821
-        """
-        Get the name property.
-
-        Returns
-        -------
-        str
-            Value of property name.
-        """
-        return self._name
-
-    @property
-    def value(self) -> int:
-        """
-        Get the value property.
-
-        Returns
-        -------
-        int
-            Value of property value.
-        """
-        return self._value
+    PRIVATE = "private"
+    PROTECTED = "protected"
+    PUBLIC = "public"

--- a/tests/unit/sam/sysml2/dto/test_commit.py
+++ b/tests/unit/sam/sysml2/dto/test_commit.py
@@ -26,6 +26,7 @@ import json
 
 from ansys.sam.sysml2.dto.commit.commit_class import Commit
 from ansys.sam.sysml2.dto.commit.data_version import DataVersion
+from ansys.sam.sysml2.meta_model.feature_direction_kind import FeatureDirectionKind
 
 
 class TestCommit:
@@ -112,3 +113,23 @@ class TestCommit:
 
         assert result["owningProject"]["@id"] == "1"
         assert result["previousCommit"]["@id"] == "head"
+
+    def test_add_change_enum_stored_as_literal(self):
+        dv = DataVersion()
+        dv.add_change("direction", FeatureDirectionKind.IN)
+
+        value = dv.to_json()["payload"]["direction"]
+
+        assert value == "in"
+        assert type(value) is str
+
+    def test_commit_enum_round_trip(self):
+        commit = Commit("proj-1")
+        change = DataVersion()
+        change.identify("elem-1")
+        change.add_change("direction", FeatureDirectionKind.IN)
+        commit.add_change(change)
+
+        result = json.loads(commit.to_json())
+
+        assert result["change"][0]["payload"]["direction"] == "in"

--- a/tests/unit/sam/sysml2/meta_model/test_feature_direction_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_feature_direction_kind.py
@@ -20,11 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Generated  test class from metamodel."""
-
-from __future__ import annotations
-
-import pytest
+"""Generated feature direction kind test class from metamodel."""
 
 from ansys.sam.sysml2.meta_model.feature_direction_kind import FeatureDirectionKind
 
@@ -32,23 +28,14 @@ from ansys.sam.sysml2.meta_model.feature_direction_kind import FeatureDirectionK
 class TestFeatureDirectionKind:
     """Test class for Java class 'com.ansys.metamodel.sysml2.FeatureDirectionKind'."""
 
-    @pytest.fixture
-    def element(self):
-        """Create test element."""
-        return FeatureDirectionKind()
+    def test_in(self):
+        """Test IN member."""
+        assert FeatureDirectionKind.IN == "in"
 
-    def test_by_name(self, element):
-        """Test getter for by name property."""
-        _ = element.by_name
+    def test_inout(self):
+        """Test INOUT member."""
+        assert FeatureDirectionKind.INOUT == "inout"
 
-    def test_literal(self, element):
-        """Test getter for literal property."""
-        _ = element.literal
-
-    def test_name(self, element):
-        """Test getter for name property."""
-        _ = element.name
-
-    def test_value(self, element):
-        """Test getter for value property."""
-        _ = element.value
+    def test_out(self):
+        """Test OUT member."""
+        assert FeatureDirectionKind.OUT == "out"

--- a/tests/unit/sam/sysml2/meta_model/test_feature_direction_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_feature_direction_kind.py
@@ -30,12 +30,12 @@ class TestFeatureDirectionKind:
 
     def test_in(self):
         """Test IN member."""
-        assert FeatureDirectionKind.IN == "in"
+        assert FeatureDirectionKind.IN.value == "in"
 
     def test_inout(self):
         """Test INOUT member."""
-        assert FeatureDirectionKind.INOUT == "inout"
+        assert FeatureDirectionKind.INOUT.value == "inout"
 
     def test_out(self):
         """Test OUT member."""
-        assert FeatureDirectionKind.OUT == "out"
+        assert FeatureDirectionKind.OUT.value == "out"

--- a/tests/unit/sam/sysml2/meta_model/test_portion_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_portion_kind.py
@@ -20,11 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Generated  test class from metamodel."""
-
-from __future__ import annotations
-
-import pytest
+"""Generated portion kind test class from metamodel."""
 
 from ansys.sam.sysml2.meta_model.portion_kind import PortionKind
 
@@ -32,23 +28,10 @@ from ansys.sam.sysml2.meta_model.portion_kind import PortionKind
 class TestPortionKind:
     """Test class for Java class 'com.ansys.metamodel.sysml2.PortionKind'."""
 
-    @pytest.fixture
-    def element(self):
-        """Create test element."""
-        return PortionKind()
+    def test_timeslice(self):
+        """Test TIMESLICE member."""
+        assert PortionKind.TIMESLICE == "timeslice"
 
-    def test_by_name(self, element):
-        """Test getter for by name property."""
-        _ = element.by_name
-
-    def test_literal(self, element):
-        """Test getter for literal property."""
-        _ = element.literal
-
-    def test_name(self, element):
-        """Test getter for name property."""
-        _ = element.name
-
-    def test_value(self, element):
-        """Test getter for value property."""
-        _ = element.value
+    def test_snapshot(self):
+        """Test SNAPSHOT member."""
+        assert PortionKind.SNAPSHOT == "snapshot"

--- a/tests/unit/sam/sysml2/meta_model/test_portion_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_portion_kind.py
@@ -30,8 +30,8 @@ class TestPortionKind:
 
     def test_timeslice(self):
         """Test TIMESLICE member."""
-        assert PortionKind.TIMESLICE == "timeslice"
+        assert PortionKind.TIMESLICE.value == "timeslice"
 
     def test_snapshot(self):
         """Test SNAPSHOT member."""
-        assert PortionKind.SNAPSHOT == "snapshot"
+        assert PortionKind.SNAPSHOT.value == "snapshot"

--- a/tests/unit/sam/sysml2/meta_model/test_requirement_constraint_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_requirement_constraint_kind.py
@@ -20,11 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Generated  test class from metamodel."""
-
-from __future__ import annotations
-
-import pytest
+"""Generated requirement constraint kind test class from metamodel."""
 
 from ansys.sam.sysml2.meta_model.requirement_constraint_kind import RequirementConstraintKind
 
@@ -32,23 +28,10 @@ from ansys.sam.sysml2.meta_model.requirement_constraint_kind import RequirementC
 class TestRequirementConstraintKind:
     """Test class for Java class 'com.ansys.metamodel.sysml2.RequirementConstraintKind'."""
 
-    @pytest.fixture
-    def element(self):
-        """Create test element."""
-        return RequirementConstraintKind()
+    def test_assumption(self):
+        """Test ASSUMPTION member."""
+        assert RequirementConstraintKind.ASSUMPTION == "assumption"
 
-    def test_by_name(self, element):
-        """Test getter for by name property."""
-        _ = element.by_name
-
-    def test_literal(self, element):
-        """Test getter for literal property."""
-        _ = element.literal
-
-    def test_name(self, element):
-        """Test getter for name property."""
-        _ = element.name
-
-    def test_value(self, element):
-        """Test getter for value property."""
-        _ = element.value
+    def test_requirement(self):
+        """Test REQUIREMENT member."""
+        assert RequirementConstraintKind.REQUIREMENT == "requirement"

--- a/tests/unit/sam/sysml2/meta_model/test_requirement_constraint_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_requirement_constraint_kind.py
@@ -30,8 +30,8 @@ class TestRequirementConstraintKind:
 
     def test_assumption(self):
         """Test ASSUMPTION member."""
-        assert RequirementConstraintKind.ASSUMPTION == "assumption"
+        assert RequirementConstraintKind.ASSUMPTION.value == "assumption"
 
     def test_requirement(self):
         """Test REQUIREMENT member."""
-        assert RequirementConstraintKind.REQUIREMENT == "requirement"
+        assert RequirementConstraintKind.REQUIREMENT.value == "requirement"

--- a/tests/unit/sam/sysml2/meta_model/test_state_subaction_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_state_subaction_kind.py
@@ -20,11 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Generated  test class from metamodel."""
-
-from __future__ import annotations
-
-import pytest
+"""Generated state subaction kind test class from metamodel."""
 
 from ansys.sam.sysml2.meta_model.state_subaction_kind import StateSubactionKind
 
@@ -32,23 +28,14 @@ from ansys.sam.sysml2.meta_model.state_subaction_kind import StateSubactionKind
 class TestStateSubactionKind:
     """Test class for Java class 'com.ansys.metamodel.sysml2.StateSubactionKind'."""
 
-    @pytest.fixture
-    def element(self):
-        """Create test element."""
-        return StateSubactionKind()
+    def test_entry(self):
+        """Test ENTRY member."""
+        assert StateSubactionKind.ENTRY == "entry"
 
-    def test_by_name(self, element):
-        """Test getter for by name property."""
-        _ = element.by_name
+    def test_do(self):
+        """Test DO member."""
+        assert StateSubactionKind.DO == "do"
 
-    def test_literal(self, element):
-        """Test getter for literal property."""
-        _ = element.literal
-
-    def test_name(self, element):
-        """Test getter for name property."""
-        _ = element.name
-
-    def test_value(self, element):
-        """Test getter for value property."""
-        _ = element.value
+    def test_exit(self):
+        """Test EXIT member."""
+        assert StateSubactionKind.EXIT == "exit"

--- a/tests/unit/sam/sysml2/meta_model/test_state_subaction_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_state_subaction_kind.py
@@ -30,12 +30,12 @@ class TestStateSubactionKind:
 
     def test_entry(self):
         """Test ENTRY member."""
-        assert StateSubactionKind.ENTRY == "entry"
+        assert StateSubactionKind.ENTRY.value == "entry"
 
     def test_do(self):
         """Test DO member."""
-        assert StateSubactionKind.DO == "do"
+        assert StateSubactionKind.DO.value == "do"
 
     def test_exit(self):
         """Test EXIT member."""
-        assert StateSubactionKind.EXIT == "exit"
+        assert StateSubactionKind.EXIT.value == "exit"

--- a/tests/unit/sam/sysml2/meta_model/test_transition_feature_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_transition_feature_kind.py
@@ -20,11 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Generated  test class from metamodel."""
-
-from __future__ import annotations
-
-import pytest
+"""Generated transition feature kind test class from metamodel."""
 
 from ansys.sam.sysml2.meta_model.transition_feature_kind import TransitionFeatureKind
 
@@ -32,23 +28,14 @@ from ansys.sam.sysml2.meta_model.transition_feature_kind import TransitionFeatur
 class TestTransitionFeatureKind:
     """Test class for Java class 'com.ansys.metamodel.sysml2.TransitionFeatureKind'."""
 
-    @pytest.fixture
-    def element(self):
-        """Create test element."""
-        return TransitionFeatureKind()
+    def test_trigger(self):
+        """Test TRIGGER member."""
+        assert TransitionFeatureKind.TRIGGER == "trigger"
 
-    def test_by_name(self, element):
-        """Test getter for by name property."""
-        _ = element.by_name
+    def test_guard(self):
+        """Test GUARD member."""
+        assert TransitionFeatureKind.GUARD == "guard"
 
-    def test_literal(self, element):
-        """Test getter for literal property."""
-        _ = element.literal
-
-    def test_name(self, element):
-        """Test getter for name property."""
-        _ = element.name
-
-    def test_value(self, element):
-        """Test getter for value property."""
-        _ = element.value
+    def test_effect(self):
+        """Test EFFECT member."""
+        assert TransitionFeatureKind.EFFECT == "effect"

--- a/tests/unit/sam/sysml2/meta_model/test_transition_feature_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_transition_feature_kind.py
@@ -30,12 +30,12 @@ class TestTransitionFeatureKind:
 
     def test_trigger(self):
         """Test TRIGGER member."""
-        assert TransitionFeatureKind.TRIGGER == "trigger"
+        assert TransitionFeatureKind.TRIGGER.value == "trigger"
 
     def test_guard(self):
         """Test GUARD member."""
-        assert TransitionFeatureKind.GUARD == "guard"
+        assert TransitionFeatureKind.GUARD.value == "guard"
 
     def test_effect(self):
         """Test EFFECT member."""
-        assert TransitionFeatureKind.EFFECT == "effect"
+        assert TransitionFeatureKind.EFFECT.value == "effect"

--- a/tests/unit/sam/sysml2/meta_model/test_trigger_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_trigger_kind.py
@@ -30,12 +30,12 @@ class TestTriggerKind:
 
     def test_when(self):
         """Test WHEN member."""
-        assert TriggerKind.WHEN == "when"
+        assert TriggerKind.WHEN.value == "when"
 
     def test_at(self):
         """Test AT member."""
-        assert TriggerKind.AT == "at"
+        assert TriggerKind.AT.value == "at"
 
     def test_after(self):
         """Test AFTER member."""
-        assert TriggerKind.AFTER == "after"
+        assert TriggerKind.AFTER.value == "after"

--- a/tests/unit/sam/sysml2/meta_model/test_trigger_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_trigger_kind.py
@@ -20,11 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Generated  test class from metamodel."""
-
-from __future__ import annotations
-
-import pytest
+"""Generated trigger kind test class from metamodel."""
 
 from ansys.sam.sysml2.meta_model.trigger_kind import TriggerKind
 
@@ -32,23 +28,14 @@ from ansys.sam.sysml2.meta_model.trigger_kind import TriggerKind
 class TestTriggerKind:
     """Test class for Java class 'com.ansys.metamodel.sysml2.TriggerKind'."""
 
-    @pytest.fixture
-    def element(self):
-        """Create test element."""
-        return TriggerKind()
+    def test_when(self):
+        """Test WHEN member."""
+        assert TriggerKind.WHEN == "when"
 
-    def test_by_name(self, element):
-        """Test getter for by name property."""
-        _ = element.by_name
+    def test_at(self):
+        """Test AT member."""
+        assert TriggerKind.AT == "at"
 
-    def test_literal(self, element):
-        """Test getter for literal property."""
-        _ = element.literal
-
-    def test_name(self, element):
-        """Test getter for name property."""
-        _ = element.name
-
-    def test_value(self, element):
-        """Test getter for value property."""
-        _ = element.value
+    def test_after(self):
+        """Test AFTER member."""
+        assert TriggerKind.AFTER == "after"

--- a/tests/unit/sam/sysml2/meta_model/test_type_.py
+++ b/tests/unit/sam/sysml2/meta_model/test_type_.py
@@ -64,6 +64,10 @@ class TestType:
         """Test getter for feature property."""
         _ = element.feature
 
+    def test_feature_exclude_implied(self, element):
+        """Test getter for feature exclude implied property."""
+        _ = element.feature_exclude_implied
+
     def test_feature_membership(self, element):
         """Test getter for feature membership property."""
         _ = element.feature_membership
@@ -75,6 +79,10 @@ class TestType:
     def test_inherited_membership(self, element):
         """Test getter for inherited membership property."""
         _ = element.inherited_membership
+
+    def test_inherited_membership_exclude_implied(self, element):
+        """Test getter for inherited membership exclude implied property."""
+        _ = element.inherited_membership_exclude_implied
 
     def test_input(self, element):
         """Test getter for input property."""

--- a/tests/unit/sam/sysml2/meta_model/test_visibility_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_visibility_kind.py
@@ -20,11 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Generated  test class from metamodel."""
-
-from __future__ import annotations
-
-import pytest
+"""Generated visibility kind test class from metamodel."""
 
 from ansys.sam.sysml2.meta_model.visibility_kind import VisibilityKind
 
@@ -32,23 +28,14 @@ from ansys.sam.sysml2.meta_model.visibility_kind import VisibilityKind
 class TestVisibilityKind:
     """Test class for Java class 'com.ansys.metamodel.sysml2.VisibilityKind'."""
 
-    @pytest.fixture
-    def element(self):
-        """Create test element."""
-        return VisibilityKind()
+    def test_private(self):
+        """Test PRIVATE member."""
+        assert VisibilityKind.PRIVATE == "private"
 
-    def test_by_name(self, element):
-        """Test getter for by name property."""
-        _ = element.by_name
+    def test_protected(self):
+        """Test PROTECTED member."""
+        assert VisibilityKind.PROTECTED == "protected"
 
-    def test_literal(self, element):
-        """Test getter for literal property."""
-        _ = element.literal
-
-    def test_name(self, element):
-        """Test getter for name property."""
-        _ = element.name
-
-    def test_value(self, element):
-        """Test getter for value property."""
-        _ = element.value
+    def test_public(self):
+        """Test PUBLIC member."""
+        assert VisibilityKind.PUBLIC == "public"

--- a/tests/unit/sam/sysml2/meta_model/test_visibility_kind.py
+++ b/tests/unit/sam/sysml2/meta_model/test_visibility_kind.py
@@ -30,12 +30,12 @@ class TestVisibilityKind:
 
     def test_private(self):
         """Test PRIVATE member."""
-        assert VisibilityKind.PRIVATE == "private"
+        assert VisibilityKind.PRIVATE.value == "private"
 
     def test_protected(self):
         """Test PROTECTED member."""
-        assert VisibilityKind.PROTECTED == "protected"
+        assert VisibilityKind.PROTECTED.value == "protected"
 
     def test_public(self):
         """Test PUBLIC member."""
-        assert VisibilityKind.PUBLIC == "public"
+        assert VisibilityKind.PUBLIC.value == "public"


### PR DESCRIPTION
API returns enum as strings : 
`'direction': 'out',`

So we need to handle the conversion into a kind type in both read and write. 

```
>root.get("Parts").get("Port").direction
<FeatureDirectionKind.OUT: 'out'>

>root.get("Parts").get("Port").direction = FeatureDirectionKind.IN

>root.get("Parts").get("Port").direction
<FeatureDirectionKind.IN: 'in'>

>root.get("Parts").get("Port").direction.name
'IN'
```