### PR TITLE
fix: change name to declared_name in unchanged code

### DIFF
--- a/doc/changelog.d/244.fixed.md
+++ b/doc/changelog.d/244.fixed.md
@@ -1,0 +1,1 @@
+Change name to declared_name in unchanged code

--- a/doc/source/_static/code/creating-elements-static.py
+++ b/doc/source/_static/code/creating-elements-static.py
@@ -45,7 +45,9 @@ bike = project.get_root_package().get("Structure").get("Bike")
 
 factory = Factory(project, ansyssysml2apiconnector)
 
-new_bicycle_frame_length = factory.create_attribute_usage(name="length", owner=bike.get("frame"))
+new_bicycle_frame_length = factory.create_attribute_usage(
+    declared_name="length", owner=bike.get("frame")
+)
 
 new_bicycle_frame_length.parse_and_set_value("60 [cm]")
 

--- a/doc/source/_static/code/creating-elements.py
+++ b/doc/source/_static/code/creating-elements.py
@@ -45,7 +45,7 @@ bike = project.get_root_package().Structure.Bike
 
 factory = Factory(project, ansyssysml2apiconnector)
 
-new_bicycle_frame_length = factory.create_attribute_usage(name="length", owner=bike.frame)
+new_bicycle_frame_length = factory.create_attribute_usage(declared_name="length", owner=bike.frame)
 
 new_bicycle_frame_length.parse_and_set_value("60 [cm]")
 

--- a/examples/code/creating-elements-static.py
+++ b/examples/code/creating-elements-static.py
@@ -46,7 +46,9 @@ bike = project.get_root_package().get("Structure").get("Bike")
 
 factory = Factory(project, ansyssysml2apiconnector)
 
-new_bicycle_frame_length = factory.create_attribute_usage(name="length", owner=bike.get("frame"))
+new_bicycle_frame_length = factory.create_attribute_usage(
+    declared_name="length", owner=bike.get("frame")
+)
 
 new_bicycle_frame_length.parse_and_set_value("60 [cm]")
 

--- a/examples/code/creating-elements.py
+++ b/examples/code/creating-elements.py
@@ -46,7 +46,7 @@ bike = project.get_root_package().Structure.Bike
 
 factory = Factory(project, ansyssysml2apiconnector)
 
-new_bicycle_frame_length = factory.create_attribute_usage(name="length", owner=bike.frame)
+new_bicycle_frame_length = factory.create_attribute_usage(declared_name="length", owner=bike.frame)
 
 bike.frame.length.parse_and_set_value("60 [cm]")
 

--- a/tests/e2e/test_commits_scripting.py
+++ b/tests/e2e/test_commits_scripting.py
@@ -45,7 +45,7 @@ class TestCommitsScripting:
         change = DataVersion()
         change.identify(bike_front_wheel_id)
         change.add_change("@type", bike_front_wheel_type)
-        change.add_change("name", "RenamedByE2E")
+        change.add_change("declaredName", "RenamedByE2E")
         commit.add_change(change)
         response = connector.create_commit(project.get_id(), commit.to_json())
 
@@ -137,7 +137,7 @@ class TestCommitsScripting:
         bike = project.get_root_package().Structure.Bike
 
         factory = Factory(project, connector)
-        req = factory.create_requirement_usage(name="testReq", owner=bike)
+        req = factory.create_requirement_usage(declared_name="testReq", owner=bike)
         req._text.extend([
             "The bicycle shall not exceed 15 kg.",
             "Measured under standard conditions.",

--- a/tests/e2e/test_commits_sysml.py
+++ b/tests/e2e/test_commits_sysml.py
@@ -44,7 +44,7 @@ class TestCommitsSysML:
         change = DataVersion()
         change.identify(bike_front_wheel_id)
         change.add_change("@type", bike_front_wheel_type)
-        change.add_change("name", "RenamedByE2ESysML")
+        change.add_change("declaredName", "RenamedByE2ESysML")
         commit.add_change(change)
         response = connector.create_commit(project.get_id(), commit.to_json())
 

--- a/tests/e2e/test_requirements_import.py
+++ b/tests/e2e/test_requirements_import.py
@@ -55,7 +55,7 @@ class TestRequirementsImportScripting:
         factory = Factory(project, connector)
 
         for row in rows:
-            req = factory.create_requirement_usage(name=row["title"], owner=bike)
+            req = factory.create_requirement_usage(declared_name=row["title"], owner=bike)
             req._text = [row["description"]]
             req._reqId = row["id"]
         bike = project.get_root_package().Structure.Bike
@@ -77,7 +77,7 @@ class TestRequirementsImportScripting:
         factory = Factory(project, connector)
         project.start_transactional_mode()
         for row in rows:
-            req = factory.create_requirement_usage(name=row["title"], owner=bike)
+            req = factory.create_requirement_usage(declared_name=row["title"], owner=bike)
             req._text = [row["description"]]
             req._reqId = row["id"]
         project.stop_transactional_mode()
@@ -103,7 +103,7 @@ class TestRequirementsImportSysML:
 
         factory = Factory(project, connector)
         for row in rows:
-            req = factory.create_requirement_usage(name=row["title"], owner=bike)
+            req = factory.create_requirement_usage(declared_name=row["title"], owner=bike)
             req._text = [row["description"]]
             req._reqId = row["id"]
         bike = project.get_root_package().get("Structure").get("Bike")
@@ -125,7 +125,7 @@ class TestRequirementsImportSysML:
         factory = Factory(project, connector)
         project.start_transactional_mode()
         for row in rows:
-            req = factory.create_requirement_usage(name=row["title"], owner=bike)
+            req = factory.create_requirement_usage(declared_name=row["title"], owner=bike)
             req._text = [row["description"]]
             req._reqId = row["id"]
         project.stop_transactional_mode()

--- a/tests/e2e/test_values.py
+++ b/tests/e2e/test_values.py
@@ -90,7 +90,7 @@ class TestValues:
         project = project_factory(model="bike", kind="scripting")
         bike = project.get_root_package().Structure.Bike
         factory = Factory(project, connector)
-        factory.create_attribute_usage(name="length", owner=bike.frame)
+        factory.create_attribute_usage(declared_name="length", owner=bike.frame)
 
         bike.frame.length.parse_and_set_value("60 [cm]")
         value = bike.frame.length.get_value()

--- a/tests/unit/sam/sysml2/tools/test_ansys_scripting_project.py
+++ b/tests/unit/sam/sysml2/tools/test_ansys_scripting_project.py
@@ -62,10 +62,10 @@ class TestAnsysScriptingProject:
         assert project._factory._project_id == PROJECT_ID_1
 
         project.start_transactional_mode()
-        new_pkg = project._factory.create_package(name="my_package", owner=root)
+        new_pkg = project._factory.create_package(declared_name="my_package", owner=root)
         project.stop_transactional_mode()
 
         assert SysMLTools.isinstance(new_pkg, "Package")
-        assert new_pkg._name == "my_package"
+        assert new_pkg._declared_name == "my_package"
         assert project.is_diagrams_available() is False
         assert project._downloader is None

--- a/tests/unit/sam/sysml2/tools/test_ansys_sysml2_project.py
+++ b/tests/unit/sam/sysml2/tools/test_ansys_sysml2_project.py
@@ -61,10 +61,10 @@ class TestAnsysSysML2Project:
         assert project._factory._project_id == PROJECT_ID_1
 
         project.start_transactional_mode()
-        new_pkg = project._factory.create_package(name="my_package", owner=root)
+        new_pkg = project._factory.create_package(declared_name="my_package", owner=root)
         project.stop_transactional_mode()
 
         assert isinstance(new_pkg, Package)
-        assert new_pkg.name == "my_package"
+        assert new_pkg.declared_name == "my_package"
         assert project.is_diagrams_available() is False
         assert project._downloader is None

--- a/tests/unit/sam/sysml2/tools/test_ansys_sysml2_project.py
+++ b/tests/unit/sam/sysml2/tools/test_ansys_sysml2_project.py
@@ -65,6 +65,5 @@ class TestAnsysSysML2Project:
         project.stop_transactional_mode()
 
         assert isinstance(new_pkg, Package)
-        assert new_pkg.declared_name == "my_package"
         assert project.is_diagrams_available() is False
         assert project._downloader is None

--- a/tests/unit/sam/sysml2/tools/test_factory.py
+++ b/tests/unit/sam/sysml2/tools/test_factory.py
@@ -59,10 +59,10 @@ class TestFactory:
         project.start_transactional_mode()
         create_fn = getattr(factory, factory_method)
 
-        elem = create_fn(name="test_elem", owner=root)
+        elem = create_fn(declared_name="test_elem", owner=root)
 
         assert elem.__class__.__name__ == element_type
-        assert elem._name == "test_elem"
+        assert elem._declared_name == "test_elem"
 
         project.stop_transactional_mode()
 
@@ -80,10 +80,10 @@ class TestFactory:
         project.start_transactional_mode()
         create_fn = getattr(factory, factory_method)
 
-        elem = create_fn(name="test_elem", owner=root)
+        elem = create_fn(declared_name="test_elem", owner=root)
 
         assert elem.__class__.__name__ == element_type
-        assert elem.name == "test_elem"
+        assert elem.declared_name == "test_elem"
 
         project.stop_transactional_mode()
 
@@ -97,14 +97,14 @@ class TestFactory:
         root = project.get_root_package()
         commit_spy = mocker.spy(project_manager._connector, "create_commit")
         project.start_transactional_mode()
-        new_attr = factory.create_attribute_usage(name="new_attribute", owner=root)
+        new_attr = factory.create_attribute_usage(declared_name="new_attribute", owner=root)
 
         new_part = factory.create_part_definition(
-            name="new_part_def", owner=root, owned_elements=[new_attr]
+            declared_name="new_part_def", owner=root, owned_elements=[new_attr]
         )
 
         assert new_part.__class__.__name__ == "PartDefinition"
-        assert new_part._name == "new_part_def"
+        assert new_part._declared_name == "new_part_def"
         assert len(new_part._owned_elements) == 1
 
         project.stop_transactional_mode()
@@ -121,7 +121,7 @@ class TestFactory:
         )
 
         with pytest.raises(BadRequestConnectionException) as exc:
-            factory._create_element(element_type=None, name="test")
+            factory._create_element(element_type=None, declared_name="test")
 
     def test_create_element_owner_invalid(self, project_manager, mocker):
         project = project_manager.get_scripting_project(PROJECT_ID_2)
@@ -133,7 +133,7 @@ class TestFactory:
         )
 
         with pytest.raises(BadRequestConnectionException):
-            factory.create_attribute_usage(name="new_attribute")
+            factory.create_attribute_usage(declared_name="new_attribute")
 
     def test_create_element_with_invalid_owner_attr(self, project_manager):
         project = project_manager.get_scripting_project(PROJECT_ID_2)
@@ -142,5 +142,5 @@ class TestFactory:
 
         with pytest.raises(AttributeError):
             factory.create_attribute_usage(
-                name="new_attribute", owner=root.UNDEFINED_ELEMENT
+                declared_name="new_attribute", owner=root.UNDEFINED_ELEMENT
             )


### PR DESCRIPTION
Some parts in the code were still using old name which triggered errors while running the tests.