### PR TITLE
refactor: move parse_and_set_value from elements to SysMLTools

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -37,6 +37,7 @@ You are likely impacted if your code does any of the following:
 | Libraries | no direct access | `project.get_libraries_packages()` |
 | Connection ends | directly usable in all cases, then via `element.get_source()` / `element.get_target()` | `SysMLTools().resolve_feature_chaining(...)` or `SysMLTools().get_connector_ends(...)` |
 | Feature values | Python-native values or tuples | value element (`.value` for literals, `SysMLTools.serialize_expression(...)` for expressions) |
+| Setting expression values | `feature.parse_and_set_value(...)` | `SysMLTools.parse_and_set_value(feature, ...)` |
 | Diagrams | navigable diagram model via REST API | removed (image download only) |
 
 ---
@@ -210,7 +211,7 @@ Feature value handling has changed significantly.
   - a 2-item tuple when a unit was involved, or
   - nothing
 - `set_value()` directly set the value
-- `parse_and_set_value()` parsed an expression and created the corresponding SysML v2 expression
+- `parse_and_set_value()` was a method on the feature that parsed an expression and created the corresponding SysML v2 expression
 
 ### Now
 
@@ -229,6 +230,14 @@ For a literal value, read its `.value` property directly:
 False
 >>> myFloatFeature.get_value().value
 10.56
+```
+
+To set an expression value, use `SysMLTools.parse_and_set_value`, which is no longer a method on the feature:
+
+```python
+>>> from ansys.sam.sysml2.tools import SysMLTools
+>>> SysMLTools.parse_and_set_value(myFeature, "5 + 5")
+>>> SysMLTools.parse_and_set_value(myUnitFeature, "10 [kg]")
 ```
 
 For an expression value (or when you want a serialized representation), use `SysMLTools.serialize_expression`:
@@ -251,7 +260,7 @@ For an expression value (or when you want a serialized representation), use `Sys
 
 If your code previously expected `get_value()` to return Python-native values, adapt it to handle value elements instead: read `.value` for literals, and use `SysMLTools.serialize_expression()` for expressions.
 
-If you relied on `parse_and_set_value()`, it is still available on the feature; the serialization helper is now provided by `SysMLTools`.
+If you relied on `feature.parse_and_set_value(...)`, replace it with `SysMLTools.parse_and_set_value(feature, ...)`. It is no longer a method on the feature; both writing expressions and serializing them are now provided by `SysMLTools`.
 
 ---
 

--- a/doc/changelog.d/255.miscellaneous.md
+++ b/doc/changelog.d/255.miscellaneous.md
@@ -1,0 +1,1 @@
+Move parse_and_set_value from elements to SysMLTools

--- a/doc/source/_static/code/creating-elements-static.py
+++ b/doc/source/_static/code/creating-elements-static.py
@@ -49,6 +49,6 @@ new_bicycle_frame_length = factory.create_attribute_usage(
     declared_name="length", owner=bike.get("frame")
 )
 
-new_bicycle_frame_length.parse_and_set_value("60 [cm]")
+SysMLTools.parse_and_set_value(new_bicycle_frame_length, "60 [cm]")
 
 print(SysMLTools.serialize_expression(bike.get("frame").get("length").get_value()))

--- a/doc/source/_static/code/creating-elements.py
+++ b/doc/source/_static/code/creating-elements.py
@@ -47,7 +47,7 @@ factory = Factory(project, ansyssysml2apiconnector)
 
 new_bicycle_frame_length = factory.create_attribute_usage(declared_name="length", owner=bike.frame)
 
-new_bicycle_frame_length.parse_and_set_value("60 [cm]")
+SysMLTools.parse_and_set_value(new_bicycle_frame_length, "60 [cm]")
 
 length = project.get_root_package().Structure.Bike.frame.length
 print(SysMLTools.serialize_expression(length.get_value()))

--- a/doc/source/examples/creating-elements.rst
+++ b/doc/source/examples/creating-elements.rst
@@ -59,7 +59,7 @@ You just created a new element and assigned a parsed value to it.
 
     You can also assign a value directly when creating the element, without using the
     :meth:`set_value() <SysMLElement.set_value>` or
-    :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>`
+    ``SysMLTools.parse_and_set_value``
     method. There are two ways:
 
     - ``value=...`` for simple values (such as numbers).

--- a/doc/source/user_guide/api/write-model.rst
+++ b/doc/source/user_guide/api/write-model.rst
@@ -9,12 +9,12 @@ Write data to your model
 Update a feature value
 ======================
 
-You have two functions for updating the value of a feature:
+You have two ways of updating the value of a feature:
 
 .. currentmodule:: ansys.sam.sysml2.classes.sysml_element
 
 - :meth:`set_value() <SysMLElement.set_value>`
-- :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>`
+- ``SysMLTools.parse_and_set_value``
 
 Function :meth:`set_value() <SysMLElement.set_value>`
 ------------------------------------------------------
@@ -38,10 +38,10 @@ The :meth:`set_value() <SysMLElement.set_value>` function supports all primitive
 
 The model updates after you set all values to ensure accuracy.
 
-Function :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>`
---------------------------------------------------------------------------
+Function ``SysMLTools.parse_and_set_value``
+-------------------------------------------
 
-The :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>` function handles more complex
+The ``SysMLTools.parse_and_set_value`` function handles more complex
 expressions. The text you pass is sent as-is to the server, which builds the corresponding
 expression; :meth:`get_value() <SysMLElement.get_value>` then returns the expression element, which
 ``SysMLTools.serialize_expression`` renders as text:
@@ -49,26 +49,26 @@ expression; :meth:`get_value() <SysMLElement.get_value>` then returns the expres
 .. code:: python
 
     >>> from ansys.sam.sysml2.tools import SysMLTools
-    >>> myFeature.parse_and_set_value("10 [m]")
+    >>> SysMLTools.parse_and_set_value(myFeature, "10 [m]")
     >>> SysMLTools.serialize_expression(myFeature.get_value())
     '10 [m]'
-    >>> myFeature.parse_and_set_value("5 + 5")
+    >>> SysMLTools.parse_and_set_value(myFeature, "5 + 5")
     >>> SysMLTools.serialize_expression(myFeature.get_value())
     '5 + 5'
-    >>> myFeature.parse_and_set_value("baseValue * 3")
+    >>> SysMLTools.parse_and_set_value(myFeature, "baseValue * 3")
     >>> SysMLTools.serialize_expression(myFeature.get_value())
     'baseValue * 3'
-    >>> myFeature.parse_and_set_value("not true")
+    >>> SysMLTools.parse_and_set_value(myFeature, "not true")
     >>> SysMLTools.serialize_expression(myFeature.get_value())
     'not true'
 
 .. note::
 
     :meth:`set_value() <SysMLElement.set_value>` and
-    :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>` are not interchangeable, even
+    ``SysMLTools.parse_and_set_value`` are not interchangeable, even
     for the same text. :meth:`set_value() <SysMLElement.set_value>` stores a string literal, whose
     ``_value`` is returned verbatim, while
-    :meth:`parse_and_set_value() <SysMLElement.parse_and_set_value>` builds an expression, which
+    ``SysMLTools.parse_and_set_value`` builds an expression, which
     ``SysMLTools.serialize_expression`` renders in its normalized form:
 
     .. code:: python
@@ -76,7 +76,7 @@ expression; :meth:`get_value() <SysMLElement.get_value>` then returns the expres
         >>> myFeature.set_value("1+2+3")
         >>> myFeature.get_value()._value
         '1+2+3'
-        >>> myFeature.parse_and_set_value("1+2+3")
+        >>> SysMLTools.parse_and_set_value(myFeature, "1+2+3")
         >>> SysMLTools.serialize_expression(myFeature.get_value())
         '1 + 2 + 3'
 
@@ -229,8 +229,8 @@ When you perform write operations, the model is updated after each operation to 
 
             my_bike_project.start_transactional_mode()
 
-            bike.frontWheel.rim.weight.parse_and_set_value("0.5 [kg]")
-            bike.rearWheel.rim.weight.parse_and_set_value("0.8 [kg]")
+            SysMLTools.parse_and_set_value(bike.frontWheel.rim.weight, "0.5 [kg]")
+            SysMLTools.parse_and_set_value(bike.rearWheel.rim.weight, "0.8 [kg]")
 
             my_bike_project.stop_transactional_mode()
 
@@ -240,8 +240,8 @@ When you perform write operations, the model is updated after each operation to 
 
             my_bike_project.start_transactional_mode()
 
-            bike.get("frontWheel").get("rim").get("weight").parse_and_set_value("0.5 [kg]")
-            bike.get("rearWheel").get("rim").get("weight").parse_and_set_value("0.8 [kg]")
+            SysMLTools.parse_and_set_value(bike.get("frontWheel").get("rim").get("weight"), "0.5 [kg]")
+            SysMLTools.parse_and_set_value(bike.get("rearWheel").get("rim").get("weight"), "0.8 [kg]")
 
             my_bike_project.stop_transactional_mode()
 

--- a/examples/code/bike-rim-weight-update-static.py
+++ b/examples/code/bike-rim-weight-update-static.py
@@ -60,8 +60,8 @@ print(f"Default rim weight: {render(rim.get('weight'))}")
 print(f"Default frontWheel rim weight: {render(bike.get('frontWheel').get('rim').get('weight'))}")
 print(f"Default RearWheel rim weight: {render(bike.get('rearWheel').get('rim').get('weight'))}")
 
-bike.get("frontWheel").get("rim").get("weight").parse_and_set_value("0.5 [kg]")
-bike.get("rearWheel").get("rim").get("weight").parse_and_set_value("0.8 [kg]")
+SysMLTools.parse_and_set_value(bike.get("frontWheel").get("rim").get("weight"), "0.5 [kg]")
+SysMLTools.parse_and_set_value(bike.get("rearWheel").get("rim").get("weight"), "0.8 [kg]")
 
 print(f"Actual rim weight: {render(rim.get('weight'))}")
 print(f"New frontWheel rim weight: {render(bike.get('frontWheel').get('rim').get('weight'))}")

--- a/examples/code/bike-rim-weight-update-transaction-static.py
+++ b/examples/code/bike-rim-weight-update-transaction-static.py
@@ -64,8 +64,8 @@ print(f"Default RearWheel rim weight: {render(bike.get('rearWheel').get('rim').g
 my_bike_project.start_transactional_mode()
 
 
-bike.get("frontWheel").get("rim").get("weight").parse_and_set_value("0.5 [kg]")
-bike.get("rearWheel").get("rim").get("weight").parse_and_set_value("0.8 [kg]")
+SysMLTools.parse_and_set_value(bike.get("frontWheel").get("rim").get("weight"), "0.5 [kg]")
+SysMLTools.parse_and_set_value(bike.get("rearWheel").get("rim").get("weight"), "0.8 [kg]")
 
 
 my_bike_project.stop_transactional_mode()

--- a/examples/code/bike-rim-weight-update-transaction.py
+++ b/examples/code/bike-rim-weight-update-transaction.py
@@ -61,8 +61,8 @@ print(f"Default rearWheel rim weight: {render(bike.rearWheel.rim.weight)}")
 
 my_bike_project.start_transactional_mode()
 
-bike.frontWheel.rim.weight.parse_and_set_value("0.5 [kg]")
-bike.rearWheel.rim.weight.parse_and_set_value("0.8 [kg]")
+SysMLTools.parse_and_set_value(bike.frontWheel.rim.weight, "0.5 [kg]")
+SysMLTools.parse_and_set_value(bike.rearWheel.rim.weight, "0.8 [kg]")
 
 my_bike_project.stop_transactional_mode()
 

--- a/examples/code/bike-rim-weight-update.py
+++ b/examples/code/bike-rim-weight-update.py
@@ -58,8 +58,8 @@ print(f"Default rim weight: {render(rim.weight)}")
 print(f"Default frontWheel rim weight: {render(bike.frontWheel.rim.weight)}")
 print(f"Default rearWheel rim weight: {render(bike.rearWheel.rim.weight)}")
 
-bike.frontWheel.rim.weight.parse_and_set_value("0.5 [kg]")
-bike.rearWheel.rim.weight.parse_and_set_value("0.8 [kg]")
+SysMLTools.parse_and_set_value(bike.frontWheel.rim.weight, "0.5 [kg]")
+SysMLTools.parse_and_set_value(bike.rearWheel.rim.weight, "0.8 [kg]")
 
 print(f"Actual rim weight: {render(rim.weight)}")
 print(f"New frontWheel rim weight: {render(bike.frontWheel.rim.weight)}")

--- a/examples/code/creating-elements-static.py
+++ b/examples/code/creating-elements-static.py
@@ -50,6 +50,6 @@ new_bicycle_frame_length = factory.create_attribute_usage(
     declared_name="length", owner=bike.get("frame")
 )
 
-new_bicycle_frame_length.parse_and_set_value("60 [cm]")
+SysMLTools.parse_and_set_value(new_bicycle_frame_length, "60 [cm]")
 
 print(SysMLTools.serialize_expression(bike.get("frame").get("length").get_value()))

--- a/examples/code/creating-elements.py
+++ b/examples/code/creating-elements.py
@@ -48,7 +48,7 @@ factory = Factory(project, ansyssysml2apiconnector)
 
 new_bicycle_frame_length = factory.create_attribute_usage(declared_name="length", owner=bike.frame)
 
-bike.frame.length.parse_and_set_value("60 [cm]")
+SysMLTools.parse_and_set_value(bike.frame.length, "60 [cm]")
 
 length = project.get_root_package().Structure.Bike.frame.length
 print(SysMLTools.serialize_expression(length.get_value()))

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -42,8 +42,8 @@ from ansys.sam.sysml2.exception.mapper_exception import MapperException
 from ansys.sam.sysml2.meta_model.element import Element
 from ansys.sam.sysml2.observer.observer import ModificationObserver
 
-_SCRIPTING_KEEP = {"get_value", "parse_and_set_value", "set_value", "delete"}
-_SYSML_KEEP = {"get", "get_value", "parse_and_set_value", "set_value", "delete"}
+_SCRIPTING_KEEP = {"get_value", "set_value", "delete"}
+_SYSML_KEEP = {"get", "get_value", "set_value", "delete"}
 
 
 class SysML2ProjectBuilder:

--- a/src/ansys/sam/sysml2/classes/sysml_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_element.py
@@ -52,7 +52,7 @@ class SysMLElement:
         children = [k for k in hmap if k is not None]
         names = set(list(base) + children)
         if not ValueHelper.is_value_capable(self):
-            names.difference_update({"get_value", "set_value", "parse_and_set_value"})
+            names.difference_update({"get_value", "set_value"})
         if not getattr(self, "_source", None):
             names.discard("get_source")
         if not getattr(self, "_target", None):
@@ -100,10 +100,6 @@ class SysMLElement:
     def get_value(self):
         """Get the value of the feature."""
         return ValueHelper.get_value_for_scripting_element(self)
-
-    def parse_and_set_value(self, value: str):
-        """Parse the value and create the valuation part in the feature."""
-        ValueHelper.set_or_update_value(self, "operator", value)
 
     def set_value(self, new_value: str | int | float | bool):
         """Update the feature value."""

--- a/src/ansys/sam/sysml2/classes/value_helper.py
+++ b/src/ansys/sam/sysml2/classes/value_helper.py
@@ -160,8 +160,8 @@ class ValueHelper:
         When no value exists a ``FeatureValue`` is created. When a literal of the same
         type already exists it is updated in place through its identity. On any value
         kind switch, including literal to operator expression (``set_value`` to
-        ``parse_and_set_value``) and back, the old value is dropped before a new
-        ``FeatureValue`` is created.
+        ``SysMLTools.parse_and_set_value``) and back, the old value is dropped before a
+        new ``FeatureValue`` is created.
 
         Parameters
         ----------

--- a/src/ansys/sam/sysml2/meta_model/e_object.py
+++ b/src/ansys/sam/sysml2/meta_model/e_object.py
@@ -48,7 +48,7 @@ class EObject:
         """Expose the public SysML API only: hide single-underscore backing fields."""
         names = [a for a in super().__dir__() if not (a.startswith("_") and not a.startswith("__"))]
         if not ValueHelper.is_value_capable(self):
-            names = [a for a in names if a not in ("get_value", "set_value", "parse_and_set_value")]
+            names = [a for a in names if a not in ("get_value", "set_value")]
         if not getattr(self, "source", None):
             names = [a for a in names if a != "get_source"]
         if not getattr(self, "target", None):
@@ -131,10 +131,6 @@ class EObject:
         if self._observer is not None:
             self._observer.delete_element(self.id)
         del self
-
-    def parse_and_set_value(self, value: str):
-        """Parse the value and create the valuation part in the Feature."""
-        ValueHelper.set_or_update_value(self, "operator", value)
 
     def set_value(self, new_value: str | int | float | bool):
         """Update the Feature value."""

--- a/src/ansys/sam/sysml2/tools/factory.py
+++ b/src/ansys/sam/sysml2/tools/factory.py
@@ -319,6 +319,7 @@ from ansys.sam.sysml2.meta_model.visibility_kind import VisibilityKind as Visibi
 from ansys.sam.sysml2.meta_model.while_loop_action_usage import (
     WhileLoopActionUsage as WhileLoopActionUsage,
 )
+from ansys.sam.sysml2.tools.sysmltools import SysMLTools
 
 
 class Factory:
@@ -2451,7 +2452,7 @@ class Factory:
         if "value" in kwargs:
             element.set_value(kwargs.get("value"))
         elif "expression" in kwargs:
-            element.parse_and_set_value(kwargs.get("expression"))
+            SysMLTools.parse_and_set_value(element, kwargs.get("expression"))
         return element
 
     def _extract_created_element(self, element_type: str, existing_elements: set):

--- a/src/ansys/sam/sysml2/tools/sysmltools.py
+++ b/src/ansys/sam/sysml2/tools/sysmltools.py
@@ -64,3 +64,24 @@ class SysMLTools:
         from ansys.sam.sysml2.classes.value_helper import ValueHelper
 
         return ValueHelper.serialize(value)
+
+    @staticmethod
+    def parse_and_set_value(feature, expression: str):
+        """
+        Parse an expression and set it as the feature's value.
+
+        The text is sent as-is to the server, which builds the corresponding SysML v2
+        expression (for example a unit expression, an arithmetic expression, or a
+        reference expression). Use :meth:`serialize_expression` to render the resulting
+        value element back to text.
+
+        Parameters
+        ----------
+        feature : SysMLElement or Element
+            Feature whose value is set or updated.
+        expression : str
+            Expression text to parse (for example ``"10 [m]"`` or ``"5 + 5"``).
+        """
+        from ansys.sam.sysml2.classes.value_helper import ValueHelper
+
+        ValueHelper.set_or_update_value(feature, "operator", expression)

--- a/tests/e2e/test_commits_scripting.py
+++ b/tests/e2e/test_commits_scripting.py
@@ -64,7 +64,7 @@ class TestCommitsScripting:
 
         assert original_front_wheel_rim_weight == "1 [kg]"
 
-        bike_front_wheel_rim_weight.parse_and_set_value("500 [g]")
+        SysMLTools.parse_and_set_value(bike_front_wheel_rim_weight, "500 [g]")
         updated_front_wheel_rim_weight = SysMLTools.serialize_expression(
             bike_front_wheel_rim_weight.get_value()
         )

--- a/tests/e2e/test_commits_sysml.py
+++ b/tests/e2e/test_commits_sysml.py
@@ -63,7 +63,7 @@ class TestCommitsSysML:
         original_bike_front_wheel_rim_weight = SysMLTools.serialize_expression(
             bike_front_wheel_rim_weight.get_value()
         )
-        bike_front_wheel_rim_weight.parse_and_set_value("500 [g]")
+        SysMLTools.parse_and_set_value(bike_front_wheel_rim_weight, "500 [g]")
         updated_bike_front_wheel_rim_weight = SysMLTools.serialize_expression(
             bike_front_wheel_rim_weight.get_value()
         )

--- a/tests/e2e/test_values.py
+++ b/tests/e2e/test_values.py
@@ -61,7 +61,7 @@ class TestValues:
 
         assert original_front_weight == "1 [kg]"
 
-        bike.frontWheel.rim.weight.parse_and_set_value("500 [g]")
+        SysMLTools.parse_and_set_value(bike.frontWheel.rim.weight, "500 [g]")
         updated_front_weight = SysMLTools.serialize_expression(
             bike.frontWheel.rim.weight.get_value()
         )
@@ -84,8 +84,8 @@ class TestValues:
         assert original_rear_weight == "1 [kg]"
 
         project.start_transactional_mode()
-        bike.frontWheel.rim.weight.parse_and_set_value("500 [g]")
-        bike.rearWheel.rim.weight.parse_and_set_value("750 [g]")
+        SysMLTools.parse_and_set_value(bike.frontWheel.rim.weight, "500 [g]")
+        SysMLTools.parse_and_set_value(bike.rearWheel.rim.weight, "750 [g]")
         project.stop_transactional_mode()
 
         updated_front_weight = SysMLTools.serialize_expression(
@@ -103,7 +103,7 @@ class TestValues:
         factory = Factory(project, connector)
         factory.create_attribute_usage(declared_name="length", owner=bike.frame)
 
-        bike.frame.length.parse_and_set_value("60 [cm]")
+        SysMLTools.parse_and_set_value(bike.frame.length, "60 [cm]")
         value = SysMLTools.serialize_expression(bike.frame.length.get_value())
 
         assert value == "60 [cm]"
@@ -146,7 +146,7 @@ class TestValues:
         factory = Factory(project, connector)
         factory.create_attribute_usage(declared_name="complexArithmetic", owner=bike.frame)
 
-        bike.frame.complexArithmetic.parse_and_set_value("5 + 5 + 5")
+        SysMLTools.parse_and_set_value(bike.frame.complexArithmetic, "5 + 5 + 5")
 
         assert (
             SysMLTools.serialize_expression(bike.frame.complexArithmetic.get_value()) == "5 + 5 + 5"
@@ -158,10 +158,10 @@ class TestValues:
         bike = project.get_root_package().Structure.Bike
         factory = Factory(project, connector)
         factory.create_attribute_usage(declared_name="baseValue", owner=bike.frame)
-        bike.frame.baseValue.parse_and_set_value("5 + 5")
+        SysMLTools.parse_and_set_value(bike.frame.baseValue, "5 + 5")
         factory.create_attribute_usage(declared_name="refValue", owner=bike.frame)
 
-        bike.frame.refValue.parse_and_set_value("baseValue + baseValue")
+        SysMLTools.parse_and_set_value(bike.frame.refValue, "baseValue + baseValue")
 
         assert SysMLTools.serialize_expression(bike.frame.baseValue.get_value()) == "5 + 5"
         assert (
@@ -189,7 +189,7 @@ class TestValues:
         factory = Factory(project, connector)
         factory.create_attribute_usage(declared_name="complexArithmetic", owner=frame)
 
-        frame.get("complexArithmetic").parse_and_set_value("5 + 5 + 5")
+        SysMLTools.parse_and_set_value(frame.get("complexArithmetic"), "5 + 5 + 5")
 
         assert (
             SysMLTools.serialize_expression(frame.get("complexArithmetic").get_value())
@@ -235,7 +235,7 @@ class TestValues:
         factory = Factory(project, connector)
         factory.create_attribute_usage(declared_name="first", owner=root)
 
-        root.first.parse_and_set_value("1+2+3+4+5")
+        SysMLTools.parse_and_set_value(root.first, "1+2+3+4+5")
 
         assert SysMLTools.serialize_expression(root.first.get_value()) == "1 + 2 + 3 + 4 + 5"
 
@@ -251,7 +251,7 @@ class TestValues:
         root.first.set_value("first_value")
         assert root.first.get_value()._value == "first_value"
 
-        root.first.parse_and_set_value("second + third * 3")
+        SysMLTools.parse_and_set_value(root.first, "second + third * 3")
 
         assert SysMLTools.serialize_expression(root.first.get_value()) == "second + third * 3"
 
@@ -264,7 +264,7 @@ class TestValues:
 
         assert SysMLTools.serialize_expression(root.flag.get_value()) == "not false"
 
-        root.flag.parse_and_set_value("not true")
+        SysMLTools.parse_and_set_value(root.flag, "not true")
 
         assert SysMLTools.serialize_expression(root.flag.get_value()) == "not true"
 
@@ -278,7 +278,7 @@ class TestValues:
 
         assert root.notAttrStr.get_value()._value == "not false"
 
-        root.notAttrStr.parse_and_set_value("second * 3")
+        SysMLTools.parse_and_set_value(root.notAttrStr, "second * 3")
         assert SysMLTools.serialize_expression(root.notAttrStr.get_value()) == "second * 3"
 
         root.notAttrStr.set_value("not true")

--- a/tests/unit/sam/sysml2/classes/test_sysml_element.py
+++ b/tests/unit/sam/sysml2/classes/test_sysml_element.py
@@ -62,7 +62,7 @@ class TestSysMLElement:
         mocker.patch.object(package._observer, "reload_project")
         commit_spy = mocker.spy(connector, "create_commit")
 
-        package.Feature.myExpressionFeature.parse_and_set_value("20 [kg]")
+        SysMLTools.parse_and_set_value(package.Feature.myExpressionFeature, "20 [kg]")
 
         assert commit_spy.call_count == 2
 
@@ -185,7 +185,7 @@ class TestSysMLElementDir:
         listing = dir(element)
         assert "get_value" in listing
         assert "set_value" in listing
-        assert "parse_and_set_value" in listing
+        assert "parse_and_set_value" not in listing
 
     def test_source_target_hidden_without_ends(self):
         element = SysMLElement("element_id")

--- a/tests/unit/sam/sysml2/classes/test_value_helper.py
+++ b/tests/unit/sam/sysml2/classes/test_value_helper.py
@@ -102,7 +102,7 @@ class TestValueHelperComplexExpressions:
         original_expr_id = attribute._valuation._value._id
         commit_spy = mocker.spy(connector, "create_commit")
 
-        attribute.parse_and_set_value("attribute4 * attribute2")
+        SysMLTools.parse_and_set_value(attribute, "attribute4 * attribute2")
 
         assert commit_spy.call_count == 2
         drop = json.loads(commit_spy.call_args_list[0].args[1])

--- a/tests/unit/sam/sysml2/meta_model/test_e_object.py
+++ b/tests/unit/sam/sysml2/meta_model/test_e_object.py
@@ -57,7 +57,9 @@ class TestEObject:
     def test_expression_set_value(self, project: Project, mocker):
         package = project.get_root_package()
         mocker.patch.object(package._observer, "reload_project")
-        package.get("Feature").get("myExpressionFeature").parse_and_set_value("20 [kg]")
+        SysMLTools.parse_and_set_value(
+            package.get("Feature").get("myExpressionFeature"), "20 [kg]"
+        )
         value = package.get("Feature").get("myExpressionFeature").get_value()
         assert value is not None
 
@@ -130,7 +132,7 @@ class TestEObjectDir:
         listing = dir(element)
         assert "get_value" in listing
         assert "set_value" in listing
-        assert "parse_and_set_value" in listing
+        assert "parse_and_set_value" not in listing
 
     def test_value_methods_listed_on_feature_descendant(self):
         element = PartUsage("element_id")
@@ -138,7 +140,7 @@ class TestEObjectDir:
         listing = dir(element)
         assert "get_value" in listing
         assert "set_value" in listing
-        assert "parse_and_set_value" in listing
+        assert "parse_and_set_value" not in listing
 
     def test_source_target_hidden_without_ends(self):
         element = Element("element_id")


### PR DESCRIPTION
parse_and_set_value is not SysML2 standard, it's linked to SAM, so we move it to SysMLTools with serialize_expression.