### PR TITLE
refactor: expose real UUID for inherited elements instead of self-built composed IDs

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -197,6 +197,8 @@ source, target = SysMLTools().get_connector_ends(connection)
 
 Replace any element-level `get_source()` / `get_target()` calls (and the former `RepresentativeResolver`) with `SysMLTools`. It auto-detects whether you use the static or dynamic representation from the element you pass in, accounts for feature chaining, inheritance, and redefinition, and returns `None` when the end or context is missing.
 
+> **Note:** Inherited elements now expose their real UUID (metamodel `.id`) instead of a self-built composed path such as `owner_id/?child_id`.
+
 ---
 
 ## 6. Feature values

--- a/doc/changelog.d/256.miscellaneous.md
+++ b/doc/changelog.d/256.miscellaneous.md
@@ -1,0 +1,1 @@
+Expose real UUID for inherited elements instead of self-built composed IDs

--- a/src/ansys/sam/sysml2/classes/inherited_element.py
+++ b/src/ansys/sam/sysml2/classes/inherited_element.py
@@ -24,35 +24,6 @@
 from ansys.sam.sysml2.classes.sysml_element import SysMLElement
 
 
-def build_composed_name(owner, element, is_inherited):
-    """
-    Build a composed name for the inherited element.
-
-    Parameters
-    ----------
-    owner : SysMLElement
-        The owner of the inherited element.
-    element : SysMLElement
-        The inherited element.
-    is_inherited : bool
-        Whether the element is inherited or not.
-
-    Returns
-    -------
-    str
-         The composed name for the inherited element.
-    """
-    is_contained_in_inherited_element = isinstance(owner, InheritedElement)
-    if is_inherited:
-        is_inherited = (
-            element in getattr(owner, "_inheritedFeature", []) or is_contained_in_inherited_element
-        )
-        if is_contained_in_inherited_element:
-            return f"{owner._id}/?{element._identifier}"
-        return f"{build_composed_name(owner._owner, owner, is_inherited)}/?{element._id}"
-    return ""
-
-
 class InheritedElement(SysMLElement):
     """Proxy that exposes an inherited element under its on-the-fly owner."""
 
@@ -61,7 +32,7 @@ class InheritedElement(SysMLElement):
         super().__init__("")
         self._observer = owner._observer
         self._element = element
-        self._id = build_composed_name(owner, element, True)
+        self._id = element._id
         self._owner = owner
 
     def __setattr__(self, name, value):

--- a/src/ansys/sam/sysml2/classes/sysml_inherited_element.py
+++ b/src/ansys/sam/sysml2/classes/sysml_inherited_element.py
@@ -24,35 +24,6 @@
 from ansys.sam.sysml2.meta_model.e_object import EObject
 
 
-def build_composed_name(owner, element, is_inherited):
-    """
-    Build a composed name for the inherited element.
-
-    Parameters
-    ----------
-    owner : EObject
-        The owner of the inherited element.
-    element : EObject
-        The inherited element.
-    is_inherited : bool
-        Whether the element is inherited or not.
-
-    Returns
-    -------
-    str
-         The composed name for the inherited element.
-    """
-    is_contained_in_inherited_element = isinstance(owner, SysMLInheritedElement)
-    if is_inherited:
-        is_inherited = (
-            element in getattr(owner, "inherited_feature", []) or is_contained_in_inherited_element
-        )
-        if is_contained_in_inherited_element:
-            return f"{owner.id}/?{element.identifier}"
-        return f"{build_composed_name(owner.owner, owner, is_inherited)}/?{element.id}"
-    return ""
-
-
 class SysMLInheritedElement(EObject):
     """Proxy that exposes an inherited element under its on-the-fly owner."""
 
@@ -62,7 +33,7 @@ class SysMLInheritedElement(EObject):
         self._observer = owner._observer
         self._element = element
         self._element_hash_map = element._element_hash_map
-        self.id = build_composed_name(owner, element, True)
+        self.id = element.id
         self.owner = owner
 
     def __dir__(self):

--- a/tests/unit/sam/sysml2/classes/test_sysml_element.py
+++ b/tests/unit/sam/sysml2/classes/test_sysml_element.py
@@ -164,6 +164,15 @@ class TestSysMLElementGet:
         assert resolved._declaredName == "Part Definition"
         assert proxy.get("missing") is None
 
+    def test_inherited_element_proxy_exposes_real_uuid(self):
+        parent, _ = self._build_parent_with_spaced_child()
+        owner = SysMLElement("owner-id")
+        owner._owner = None
+        proxy = InheritedElement(owner, parent)
+
+        assert proxy._id == parent._id
+        assert "/?" not in proxy._id
+
 
 class TestSysMLElementDir:
     """dir() lists value and connection helpers only when applicable."""

--- a/tests/unit/sam/sysml2/meta_model/test_e_object.py
+++ b/tests/unit/sam/sysml2/meta_model/test_e_object.py
@@ -26,6 +26,7 @@ import pytest
 
 from ansys.sam.sysml2.builder.sysml2_project_manager import SysML2ProjectManager
 from ansys.sam.sysml2.classes.project import Project
+from ansys.sam.sysml2.classes.sysml_inherited_element import SysMLInheritedElement
 from ansys.sam.sysml2.meta_model.element import Element
 from ansys.sam.sysml2.meta_model.feature import Feature
 from ansys.sam.sysml2.meta_model.part_usage import PartUsage
@@ -111,6 +112,18 @@ class TestEObject:
         commit_spy = mocker.spy(connector, "create_commit")
         package.get("Feature").get("myFloatFeature").set_value(20.5)
         assert commit_spy.call_count == 1
+
+
+class TestSysMLInheritedElement:
+    """The inherited-element proxy exposes the wrapped element's real UUID."""
+
+    def test_proxy_exposes_real_uuid(self):
+        element = Element("base-uuid")
+        owner = Element("owner-uuid")
+        proxy = SysMLInheritedElement(owner, element)
+
+        assert proxy.id == element.id
+        assert "/?" not in proxy.id
 
 
 class TestEObjectDir:


### PR DESCRIPTION
Inherited-element proxies now carry the wrapped element's real UUID instead of a self-built owner/?child composed ID, matching SAM's UUID-based payloads.