### PR TITLE
fix: preload roots before build and resolve root package via Namespace

### DIFF
--- a/doc/changelog.d/272.fixed.md
+++ b/doc/changelog.d/272.fixed.md
@@ -1,0 +1,1 @@
+Preload roots before build and resolve root package via Namespace

--- a/src/ansys/sam/sysml2/builder/classes/project_impl.py
+++ b/src/ansys/sam/sysml2/builder/classes/project_impl.py
@@ -25,6 +25,7 @@
 from ansys.sam.sysml2.classes.project import Project
 from ansys.sam.sysml2.classes.unresolved_field import UnresolvedField
 from ansys.sam.sysml2.meta_model.element import Element
+from ansys.sam.sysml2.meta_model.namespace import Namespace
 from ansys.sam.sysml2.meta_model.namespace_import import NamespaceImport
 from ansys.sam.sysml2.meta_model.package import Package
 
@@ -78,10 +79,14 @@ class ProjectImpl(Project):
 
     def get_root_package(self) -> Package:
         """Get the root package."""
-        matches = [x for x in self._root if isinstance(x, Package)]
-        if not matches:
-            raise ValueError("No root Package found in project.")
-        return matches[0]
+        # ``Package`` subclasses ``Namespace``, so an exact type match is required to skip
+        # the root packages the API also returns in /roots.
+        namespace = next((x for x in self._root if type(x) is Namespace), None)
+        if namespace is not None:
+            for member in namespace.owned_member:
+                if isinstance(member, Package):
+                    return member
+        raise ValueError("No root Package found in project.")
 
     def get_libraries_packages(self) -> list[Package]:
         """

--- a/src/ansys/sam/sysml2/builder/classes/scripting_project_impl.py
+++ b/src/ansys/sam/sysml2/builder/classes/scripting_project_impl.py
@@ -76,10 +76,12 @@ class ScriptingProjectImpl(ScriptingProject):
 
     def get_root_package(self) -> SysMLElement:
         """Get the root package."""
-        matches = [x for x in self._root if x.__class__.__name__ == "Package"]
-        if not matches:
-            raise ValueError("No root Package found in project.")
-        return matches[0]
+        namespace = next((x for x in self._root if x.__class__.__name__ == "Namespace"), None)
+        if namespace is not None:
+            for member in namespace._ownedMember:
+                if member.__class__.__name__ == "Package":
+                    return member
+        raise ValueError("No root Package found in project.")
 
     def get_libraries_packages(self) -> list[SysMLElement]:
         """

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -125,8 +125,16 @@ class SysML2ProjectBuilder:
 
     def _build_project_element(self, project: Project | ScriptingProject):
         """Build all project elements in the project."""
-        elements = self._connector.get_all_elements(project_id=project._id)
-        self._map_element_in_project(project, elements)
+        roots_json = self._connector.get_root_elements(project_id=project._id)
+        root_ids = {root["@id"] for root in roots_json}
+
+        elements_json = self._connector.get_all_elements(project_id=project._id)
+        known_ids = {element["@id"] for element in elements_json}
+        # The API omits the root Namespace from /elements; mapping an element twice would
+        # stack a second UnresolvedField and duplicate it in list fields on resolve.
+        elements_json.extend(root for root in roots_json if root["@id"] not in known_ids)
+
+        self._map_element_in_project(project, elements_json)
         missing_elements = self._resolve_fields(project)
         seen = missing_elements.copy()
         while missing_elements:
@@ -135,20 +143,20 @@ class SysML2ProjectBuilder:
             missing_elements = self._resolve_fields(project)
             missing_elements.difference_update(seen)
             seen.update(missing_elements)
-        self.extract_root_and_check_names(project)
+        self.extract_root_and_check_names(project, root_ids)
 
-    def extract_root_and_check_names(self, project: Project | ScriptingProject):
+    def extract_root_and_check_names(self, project: Project | ScriptingProject, root_ids: set[str]):
         """Extract root elements and resolve inherited names in a single pass."""
         roots = []
         if isinstance(project, Project):
             for element in project._env.values():
                 element.declared_name = SysMLUtil.check_sysml_inherited_name(element)
-                if self._is_logical_root(element, "owner"):
+                if element.id in root_ids:
                     roots.append(element)
         elif isinstance(project, ScriptingProject):
             for element in project._env.values():
                 element._declaredName = SysMLUtil.check_inherited_name(element)
-                if self._is_logical_root(element, "_owner"):
+                if element._id in root_ids:
                     roots.append(element)
         else:
             raise TypeError(
@@ -156,13 +164,6 @@ class SysML2ProjectBuilder:
                 "Expected Project or ScriptingProject."
             )
         project._root = roots
-
-    def _is_logical_root(self, element, owner_attr: str) -> bool:
-        """Decide whether ``element`` is a user-facing root of the model."""
-        owner = getattr(element, owner_attr, None)
-        if owner is None:
-            return element.__class__.__name__ != "Namespace"
-        return owner.__class__.__name__ == "Namespace" and getattr(owner, owner_attr, None) is None
 
     def _get_mapper(self, project: Project | ScriptingProject) -> Mapper:
         """

--- a/tests/unit/mocked_connector.py
+++ b/tests/unit/mocked_connector.py
@@ -147,11 +147,23 @@ class MockedSysML2APIConnector(SysML2APIConnector):
         )
 
     def get_root_elements(self, project_id: str) -> list:
-        """Get root elements."""
+        """Get the root Namespace, its owned members, and the root imports."""
         if project_id not in self._projects:
             raise ProjectNotFoundException(f"Project {project_id} not found")
         elements = self._load_elements(project_id)
-        return [el for el in elements if el.get("owner") is None]
+        by_id = {element["@id"]: element for element in elements}
+        roots = {}
+        for element in elements:
+            if element.get("owner") is not None:
+                continue
+            if element.get("@type") == "Namespace":
+                roots[element["@id"]] = element
+                for ref in element.get("ownedMember", []):
+                    if ref["@id"] in by_id:
+                        roots[ref["@id"]] = by_id[ref["@id"]]
+            elif element.get("@type") == "NamespaceImport":
+                roots[element["@id"]] = element
+        return list(roots.values())
 
     def execute_query(self, project_id: str, query: str) -> dict:
         """Return the library elements matching the query's @id constraints."""


### PR DESCRIPTION
To retrieve the root package, we were using elements route to gather the namespace and package elements, but recently, API changes don't give us the namespace element anymore. We need to change the flow to first gather the namespace with roots route and then gather the elements via elements route. 