### PR TITLE
fix: round-trip LiteralString values with KerML string-literal escaping

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -280,6 +280,24 @@ If your code previously expected `get_value()` to return Python-native values, a
 
 If you relied on `feature.parse_and_set_value(...)`, replace it with `SysMLTools.parse_and_set_value(feature, ...)`. It is no longer a method on the feature; both writing expressions and serializing them are now provided by `SysMLTools`.
 
+### String literals and backslashes
+
+`LiteralString` values are exchanged with the server using KerML string-literal escaping.
+
+- **Create** a string value with `set_value(...)`: PySAM wraps and escapes the text as a KerML literal before the server parses it (so content such as `Hello\World` or embedded quotes round-trips correctly).
+- **Update** an existing `LiteralString` in place: PySAM still writes the raw Python string (unchanged).
+- **Read** (`get_value().value` / `._value`): if the API returns KerML-escaped text, PySAM unescapes it to the decoded content. Values that already contain real control characters (`\n`, `\r`, `\t`) are left as-is so already-decoded payloads are not corrupted.
+
+```python
+>>> attr.set_value("try\\to")
+>>> attr.get_value().value
+'try\\to'
+>>> attr.get_value().value.count("\\")
+1
+```
+
+If your scripts compared `LiteralString` values against KerML-escaped forms (for example expecting `'try\\\\to'` when the model holds a single backslash), update those comparisons to the decoded content.
+
 ---
 
 ## 7. Enum-valued properties

--- a/doc/changelog.d/275.fixed.md
+++ b/doc/changelog.d/275.fixed.md
@@ -1,0 +1,1 @@
+Round-trip LiteralString values with KerML string-literal escaping

--- a/src/ansys/sam/sysml2/builder/mapper/mapper.py
+++ b/src/ansys/sam/sysml2/builder/mapper/mapper.py
@@ -129,6 +129,14 @@ class Mapper(ABC):
         """
         # Bypass the scripting read-only guard on ``_name``: this is deserialization,
         # not a user edit, so it must not raise or stack an observer change.
+        if (
+            field_name == "_value"
+            and type(element).__name__ == "LiteralString"
+            and isinstance(field_value, str)
+        ):
+            from ansys.sam.sysml2.classes.value_helper import ValueHelper
+
+            field_value = ValueHelper.unescape_kerml_string(field_value)
         object.__setattr__(element, field_name, field_value)
         return []
 

--- a/src/ansys/sam/sysml2/classes/value_helper.py
+++ b/src/ansys/sam/sysml2/classes/value_helper.py
@@ -22,11 +22,15 @@
 
 """Value helper class for Feature's value."""
 
+import re
 from uuid import uuid4
 
 from ansys.sam.sysml2.dto.commit.commit_class import Commit
 from ansys.sam.sysml2.dto.commit.data_version import DataVersion
 from ansys.sam.sysml2.exception.runtime_exception import UnsupportedValueExpression
+
+_KERML_UNESCAPE_RE = re.compile(r'\\([\\"nrt]|.)')
+_KERML_UNESCAPE_MAP = {"\\": "\\", '"': '"', "n": "\n", "r": "\r", "t": "\t"}
 
 
 class ValueHelper:
@@ -218,12 +222,38 @@ class ValueHelper:
         commit.add_change(change)
         element._observer._connector.create_commit(project_id, commit.to_json())
 
+    @staticmethod
+    def escape_kerml_string(text: str) -> str:
+        """Escape a string for use inside a KerML string literal."""
+        return (
+            text.replace("\\", "\\\\")
+            .replace('"', '\\"')
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+        )
+
+    @staticmethod
+    def unescape_kerml_string(text: str) -> str:
+        r"""Decode KerML escapes; leave already-decoded strings (real \n/\r/\t) unchanged."""
+        if any(char in text for char in "\n\r\t"):
+            return text
+        return _KERML_UNESCAPE_RE.sub(
+            lambda match: _KERML_UNESCAPE_MAP.get(match.group(1), match.group(1)),
+            text,
+        )
+
     def _adapt_value(self, new_value: str | int | float | bool):
-        """Convert the value to JSON format."""
+        """
+        Convert the value for a new ``FeatureValue`` payload.
+
+        Strings are serialized as a quoted KerML string literal with escapes so the
+        server can parse them when creating a ``FeatureValue``.
+        """
         if isinstance(new_value, bool):
             return "true" if new_value else "false"
         if isinstance(new_value, str):
-            return f'"{new_value}"'
+            return f'"{ValueHelper.escape_kerml_string(new_value)}"'
         else:
             return str(new_value)
 

--- a/tests/e2e/test_values.py
+++ b/tests/e2e/test_values.py
@@ -295,3 +295,57 @@ class TestValues:
         root.first.set_value("second_value")
 
         assert root.first.get_value()._value == "second_value"
+
+    def test_backslash_create_and_read(self, connector, project_factory):
+        """Create a string with a backslash via set_value and read it back unchanged."""
+        project = project_factory(model="bike", kind="scripting")
+        root = project.get_root_package()
+        factory = Factory(project, connector)
+        factory.create_attribute_usage(declared_name="pathAttr", owner=root)
+
+        root.pathAttr.set_value("Hello\\World")
+
+        value = root.pathAttr.get_value()._value
+        assert value == "Hello\\World"
+        assert value.count("\\") == 1
+
+    def test_backslash_update_in_place(self, connector, project_factory):
+        """Update an existing LiteralString in place with a backslash value."""
+        project = project_factory(model="bike", kind="scripting")
+        root = project.get_root_package()
+        factory = Factory(project, connector)
+        factory.create_attribute_usage(declared_name="pathAttr", owner=root)
+
+        root.pathAttr.set_value("plain")
+        root.pathAttr.set_value("try\\to")
+
+        value = root.pathAttr.get_value()._value
+        assert value == "try\\to"
+        assert value.count("\\") == 1
+
+    def test_backslash_parse_and_set_value_quoted_kerml(self, connector, project_factory):
+        """parse_and_set_value accepts a quoted KerML string literal with escapes."""
+        project = project_factory(model="bike", kind="scripting")
+        root = project.get_root_package()
+        factory = Factory(project, connector)
+        factory.create_attribute_usage(declared_name="pathAttr", owner=root)
+
+        SysMLTools.parse_and_set_value(root.pathAttr, '"Hello\\\\World"')
+
+        value = root.pathAttr.get_value()._value
+        assert value == "Hello\\World"
+        assert value.count("\\") == 1
+
+    def test_backslash_newline_roundtrip(self, connector, project_factory):
+        """Roundtrip a string with two backslashes and a real newline."""
+        project = project_factory(model="bike", kind="scripting")
+        root = project.get_root_package()
+        factory = Factory(project, connector)
+        factory.create_attribute_usage(declared_name="pathAttr", owner=root)
+
+        root.pathAttr.set_value("try\\\\\nto")
+
+        value = root.pathAttr.get_value()._value
+        assert value == "try\\\\\nto"
+        assert value.count("\\") == 2
+        assert "\n" in value

--- a/tests/unit/sam/sysml2/builder/test_scripting_mapper.py
+++ b/tests/unit/sam/sysml2/builder/test_scripting_mapper.py
@@ -132,3 +132,17 @@ class TestScriptingMapper:
         assert element._id == "element_id"
         assert element.__class__.__name__ == "PartUsage"
         assert element._owner is owner
+
+    def test_literal_string_value_unescapes_kerml(self, scripting_mapper: ScriptingMapper):
+        """API KerML-escaped LiteralString.value is decoded on map."""
+        data = {
+            "@id": "literal_id",
+            "@type": "LiteralString",
+            "value": "try\\\\to",
+        }
+
+        element = scripting_mapper.map(data, None).get_element()
+
+        assert element.__class__.__name__ == "LiteralString"
+        assert element._value == "try\\to"
+        assert element._value.count("\\") == 1

--- a/tests/unit/sam/sysml2/builder/test_sysml_mapper.py
+++ b/tests/unit/sam/sysml2/builder/test_sysml_mapper.py
@@ -145,3 +145,17 @@ class TestSysMLMapper:
         element = sysml_mapper.map(data, None).get_element()
 
         assert element.is_abstract is True
+
+    def test_literal_string_value_unescapes_kerml(self, sysml_mapper: SysMLMapper):
+        """API KerML-escaped LiteralString.value is decoded on map."""
+        data = {
+            "@id": "literal_id",
+            "@type": "LiteralString",
+            "value": "try\\\\to",
+        }
+
+        element = sysml_mapper.map(data, None).get_element()
+
+        assert element.__class__.__name__ == "LiteralString"
+        assert element.value == "try\\to"
+        assert element.value.count("\\") == 1

--- a/tests/unit/sam/sysml2/classes/test_value_helper.py
+++ b/tests/unit/sam/sysml2/classes/test_value_helper.py
@@ -27,6 +27,7 @@ import json
 import pytest
 
 from ansys.sam.sysml2.builder.sysml2_project_manager import SysML2ProjectManager
+from ansys.sam.sysml2.classes.value_helper import ValueHelper
 from ansys.sam.sysml2.tools.sysmltools import SysMLTools
 from tests.unit.const import PROJECT_ID_5
 
@@ -130,3 +131,63 @@ class TestValueHelperComplexExpressions:
         payload = committed["change"][-1]["payload"]
         assert payload["@type"] == "FeatureValue"
         assert payload["value"] == '"attribute4 * attribute2"'
+
+    def test_adapt_value_escapes_kerml_string_literal(self):
+        helper = ValueHelper("_")
+
+        assert helper._adapt_value("Hello\\World") == '"Hello\\\\World"'
+        assert helper._adapt_value("try\\to") == '"try\\\\to"'
+        assert helper._adapt_value('say "hi"') == '"say \\"hi\\""'
+        assert helper._adapt_value("a\tb\nc\rd") == '"a\\tb\\nc\\rd"'
+
+    def test_unescape_kerml_string(self):
+        assert ValueHelper.unescape_kerml_string("try\\\\to") == "try\\to"
+        assert ValueHelper.unescape_kerml_string("Hello\\\\World") == "Hello\\World"
+        assert ValueHelper.unescape_kerml_string('say \\"hi\\"') == 'say "hi"'
+        assert ValueHelper.unescape_kerml_string("a\\tb\\nc\\rd") == "a\tb\nc\rd"
+
+    def test_unescape_kerml_string_leaves_decoded_controls(self):
+        decoded = "try\\\\\nto"
+        assert decoded.count("\\") == 2
+        assert "\n" in decoded
+        assert ValueHelper.unescape_kerml_string(decoded) == decoded
+
+    def test_escape_unescape_kerml_string_roundtrip(self):
+        samples = [
+            "Hello\\World",
+            'say "hi"',
+            "a\tb\nc",
+            "plain",
+            "try\\\\\nto",
+        ]
+        for sample in samples:
+            escaped = ValueHelper.escape_kerml_string(sample)
+            assert ValueHelper.unescape_kerml_string(escaped) == sample
+
+    def test_set_value_commits_escaped_backslash_string(self, connector, mocker):
+        project = SysML2ProjectManager(connector).get_scripting_project(PROJECT_ID_5)
+        package = project.get_root_package()
+        attribute = package.get("attribute")
+        mocker.patch.object(attribute._observer, "reload_project")
+        commit_spy = mocker.spy(connector, "create_commit")
+
+        attribute.set_value("Hello\\World")
+
+        committed = json.loads(commit_spy.call_args.args[1])
+        payload = committed["change"][-1]["payload"]
+        assert payload["@type"] == "FeatureValue"
+        assert payload["value"] == '"Hello\\\\World"'
+
+    def test_set_value_commits_escaped_quote_string(self, connector, mocker):
+        project = SysML2ProjectManager(connector).get_scripting_project(PROJECT_ID_5)
+        package = project.get_root_package()
+        attribute = package.get("attribute")
+        mocker.patch.object(attribute._observer, "reload_project")
+        commit_spy = mocker.spy(connector, "create_commit")
+
+        attribute.set_value('say "hi"')
+
+        committed = json.loads(commit_spy.call_args.args[1])
+        payload = committed["change"][-1]["payload"]
+        assert payload["@type"] == "FeatureValue"
+        assert payload["value"] == '"say \\"hi\\""'


### PR DESCRIPTION
Fix the issue with values containing multiple backslashes in PySAM.

Issue: #180 
