### PR TITLE
fix: repair e2e transactional documentation links and KerML literal string updates

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -509,8 +509,9 @@ project = manager.get_sysml_project(
 
 When `includes_derived=False`, PySAM rebuilds the main local derived collections from
 `ownedRelationship` (and from `inheritedMembership` when present), including for example
-`ownedElement`, `ownedMembership`, `ownedMember`, `ownedFeature`, `feature`, and
-`inheritedFeature`. Unresolved library references are not inserted into those collections.
+`ownedElement`, `ownedMembership`, `ownedMember`, `ownedFeature`, `feature`,
+`inheritedFeature`, and requirement `text` from each attached `documentation.body`.
+Unresolved library references are not inserted into those collections.
 
 ---
 

--- a/doc/changelog.d/288.fixed.md
+++ b/doc/changelog.d/288.fixed.md
@@ -1,0 +1,1 @@
+Repair e2e transactional documentation links and KerML literal string updates

--- a/src/ansys/sam/sysml2/builder/derived_collections.py
+++ b/src/ansys/sam/sysml2/builder/derived_collections.py
@@ -81,6 +81,7 @@ _OWNED_MEMBER = "ownedMember"
 _OWNED_IMPORT = "ownedImport"
 _OWNED_ANNOTATION = "ownedAnnotation"
 _DOCUMENTATION = "documentation"
+_TEXT = "text"
 _OWNED_FEATURE_MEMBERSHIP = "ownedFeatureMembership"
 _OWNED_FEATURE = "ownedFeature"
 _FEATURE_MEMBERSHIP = "featureMembership"
@@ -218,11 +219,13 @@ def _derive_collections_for_element(element, is_scripting: bool) -> None:
 
     _set_collection(element, _attribute_name(_OWNED_ELEMENT, is_scripting), owned_elements)
     _set_collection(element, _attribute_name(_OWNED_ANNOTATION, is_scripting), owned_annotations)
+    documentation = _filter_by_type(owned_elements, _DOCUMENTATION_TYPE_NAMES)
     _set_collection(
         element,
         _attribute_name(_DOCUMENTATION, is_scripting),
-        _filter_by_type(owned_elements, _DOCUMENTATION_TYPE_NAMES),
+        documentation,
     )
+    _derive_requirement_text(element, documentation, is_scripting)
 
     if _has_type(element, _NAMESPACE_TYPE_NAMES):
         _set_collection(
@@ -510,6 +513,19 @@ def _has_type(element, type_names: frozenset[str]) -> bool:
     """Return whether ``element``'s class name is in ``type_names``."""
     class_name = element.__class__.__name__.split(".")[-1]
     return class_name in type_names
+
+
+def _derive_requirement_text(element, documentation: list, is_scripting: bool) -> None:
+    """Fill ``text`` from documentation bodies when the element exposes ``_text``."""
+    text_attribute = _attribute_name(_TEXT, is_scripting)
+    if not hasattr(element, text_attribute):
+        return
+    bodies = []
+    for document in documentation:
+        body = getattr(document, "_body", None)
+        if body:
+            bodies.append(body)
+    _set_collection(element, text_attribute, bodies)
 
 
 def _as_list(value) -> list:

--- a/src/ansys/sam/sysml2/classes/value_helper.py
+++ b/src/ansys/sam/sysml2/classes/value_helper.py
@@ -208,7 +208,7 @@ class ValueHelper:
         commit = Commit(project_id)
         change = DataVersion()
         change.add_change("@type", literal_type)
-        change.add_change("value", new_value)
+        change.add_change("value", self._adapt_value(new_value))
         change.identify(literal._id)
         commit.add_change(change)
         element._observer._connector.create_commit(project_id, commit.to_json())

--- a/src/ansys/sam/sysml2/classes/value_helper.py
+++ b/src/ansys/sam/sysml2/classes/value_helper.py
@@ -208,7 +208,10 @@ class ValueHelper:
         commit = Commit(project_id)
         change = DataVersion()
         change.add_change("@type", literal_type)
-        change.add_change("value", self._adapt_value(new_value))
+        if literal_type == "LiteralString" and isinstance(new_value, str):
+            change.add_change("value", ValueHelper.escape_kerml_string(new_value))
+        else:
+            change.add_change("value", self._adapt_value(new_value))
         change.identify(literal._id)
         commit.add_change(change)
         element._observer._connector.create_commit(project_id, commit.to_json())

--- a/src/ansys/sam/sysml2/observer/observer.py
+++ b/src/ansys/sam/sysml2/observer/observer.py
@@ -235,19 +235,67 @@ class ModificationObserver:
         """Connect the observer."""
         self._working_observer = True
 
+    @staticmethod
+    def _normalized_fields(
+        stacked_changes: list[tuple[str, Any]],
+    ) -> list[tuple[str, Any]]:
+        """Strip leading underscores from scripting-style field names."""
+        fields = []
+        for field_name, value in stacked_changes:
+            if field_name.startswith("_"):
+                field_name = field_name[1:]
+            fields.append((field_name, value))
+        return fields
+
+    @staticmethod
+    def _is_create(fields: list[tuple[str, Any]]) -> bool:
+        """Return True when the stacked fields include an element ``@type``."""
+        for field_name, _value in fields:
+            if field_name == "@type":
+                return True
+        return False
+
+    @staticmethod
+    def _partition_create_fields_and_list_links(
+        fields: list[tuple[str, Any]],
+    ) -> tuple[list[tuple[str, Any]], list[tuple[str, Any]]]:
+        """Split non-list create fields from list link fields."""
+        create_fields = []
+        list_links = []
+        for field_name, value in fields:
+            if isinstance(value, list):
+                list_links.append((field_name, value))
+            else:
+                create_fields.append((field_name, value))
+        return create_fields, list_links
+
+    def _add_change(self, commit: Commit, element_id: str, fields: list[tuple[str, Any]]) -> None:
+        """Build a DataVersion from fields and append it to the commit."""
+        change = DataVersion()
+        if not element_id.startswith("value:"):
+            change.identify(element_id)
+        for field_name, value in fields:
+            change.add_change(field_name, value)
+        commit.add_change(change)
+
     def _commit_stack(self):
         """Commit all stacked changes."""
         commit = Commit(self._project_id)
-        for key, changes in self._stack.items():
-            change = DataVersion()
-            if not key.startswith("value:"):
-                change.identify(key)
-            for field in changes:
-                field_name = field[0]
-                if field_name.startswith("_"):
-                    field_name = field_name[1:]
-                change.add_change(field_name, field[1])
-            commit.add_change(change)
+        deferred_list_updates = []
+
+        for element_id, stacked_changes in self._stack.items():
+            fields = self._normalized_fields(stacked_changes)
+            if self._is_create(fields):
+                create_fields, list_links = self._partition_create_fields_and_list_links(fields)
+                self._add_change(commit, element_id, create_fields)
+                if list_links:
+                    deferred_list_updates.append((element_id, list_links))
+            else:
+                self._add_change(commit, element_id, fields)
+
+        for element_id, list_links in deferred_list_updates:
+            self._add_change(commit, element_id, list_links)
+
         if len(commit.changes) > 0:
             self._connector.create_commit(self._project_id, commit.to_json())
             self.reload_project()

--- a/src/ansys/sam/sysml2/tools/factory.py
+++ b/src/ansys/sam/sysml2/tools/factory.py
@@ -2384,6 +2384,7 @@ class Factory:
             Created element.
         """
         from ansys.sam.sysml2.builder.classes.sysml_util import SysMLUtil
+        from ansys.sam.sysml2.data_structures.observed_list import ObservedList
 
         element_id = str(uuid4())
         is_scripting = not isinstance(self._project, Project)
@@ -2393,6 +2394,7 @@ class Factory:
         else:
             instance = SysMLElement(element_id)
             instance.__class__ = type(element_type, (SysMLElement,), {})
+            self._init_scripting_observed_lists(instance, element_type)
 
         instance._observer = self._project.get_root_package()._observer
         instance._observer.notify(element_id, "@type", element_type)
@@ -2402,10 +2404,6 @@ class Factory:
                 attr_name = "_" + key
             if isinstance(value, list):
                 if not hasattr(instance, attr_name):
-                    from ansys.sam.sysml2.data_structures.observed_list import (
-                        ObservedList,
-                    )
-
                     setattr(instance, attr_name, ObservedList(owner=instance, name=attr_name))
                 getattr(instance, attr_name).extend(value)
             elif attr_name in ("name", "_name"):
@@ -2415,6 +2413,25 @@ class Factory:
                 setattr(instance, attr_name, value)
         self._project.add_element(instance)
         return instance
+
+    def _init_scripting_observed_lists(self, instance: SysMLElement, element_type: str) -> None:
+        """Copy empty ObservedList slots from the SysML constructor onto a scripting instance."""
+        from ansys.sam.sysml2.builder.classes.sysml_util import SysMLUtil
+        from ansys.sam.sysml2.data_structures.observed_list import ObservedList
+
+        try:
+            constructor = SysMLUtil.get_sysml_constructor(element_type)
+        except ImportError:
+            return
+
+        prototype = constructor(instance._id)
+        for attribute_name, attribute_value in prototype.__dict__.items():
+            if isinstance(attribute_value, ObservedList):
+                setattr(
+                    instance,
+                    attribute_name,
+                    ObservedList(owner=instance, name=attribute_value._name),
+                )
 
     def _direct_create_element(self, element_type, **kwargs):
         """

--- a/tests/unit/sam/sysml2/builder/test_derived_collections.py
+++ b/tests/unit/sam/sysml2/builder/test_derived_collections.py
@@ -43,6 +43,7 @@ from ansys.sam.sysml2.meta_model.owning_membership import OwningMembership
 from ansys.sam.sysml2.meta_model.package import Package
 from ansys.sam.sysml2.meta_model.part_definition import PartDefinition
 from ansys.sam.sysml2.meta_model.reference_subsetting import ReferenceSubsetting
+from ansys.sam.sysml2.meta_model.requirement_usage import RequirementUsage
 from ansys.sam.sysml2.meta_model.subclassification import Subclassification
 from ansys.sam.sysml2.meta_model.subsetting import Subsetting
 from tests.unit.const import PROJECT_ID_1
@@ -113,6 +114,30 @@ class TestFillDerivedCollectionsSysML:
         assert package.owned_annotation == [annotation]
         assert package.owned_import == [namespace_import]
         assert package.owned_member == [documentation]
+
+    def test_requirement_text_from_documentation_body(self):
+        project = ProjectImpl("p1", "project")
+        project._includes_derived = False
+
+        requirement = RequirementUsage("req")
+        documentation = Documentation("doc")
+        documentation.body = "The bicycle shall not exceed 15 kg total weight"
+        owning = OwningMembership("own")
+        owning.owned_member_element = documentation
+        requirement.owned_relationship.append(owning)
+
+        project._env = {
+            requirement.id: requirement,
+            documentation.id: documentation,
+            owning.id: owning,
+        }
+
+        fill_derived_collections(project)
+
+        assert requirement.documentation == [documentation]
+        assert list(requirement.text) == [
+            "The bicycle shall not exceed 15 kg total weight",
+        ]
 
     def test_owned_member_ignores_plain_membership(self):
         project = ProjectImpl("p1", "project")

--- a/tests/unit/sam/sysml2/classes/test_value_helper.py
+++ b/tests/unit/sam/sysml2/classes/test_value_helper.py
@@ -191,3 +191,24 @@ class TestValueHelperComplexExpressions:
         payload = committed["change"][-1]["payload"]
         assert payload["@type"] == "FeatureValue"
         assert payload["value"] == '"say \\"hi\\""'
+
+    def test_commit_literal_update_escapes_kerml_string(self, mocker):
+        """In-place LiteralString updates must KerML-escape like FeatureValue creates."""
+        helper = ValueHelper("_")
+        connector = mocker.Mock()
+        observer = mocker.Mock()
+        observer._project_id = "project-id"
+        observer._connector = connector
+        feature = mocker.Mock()
+        feature._observer = observer
+        literal = mocker.Mock()
+        literal._id = "literal-id"
+
+        helper._commit_literal_update(feature, literal, "LiteralString", "try\\to")
+
+        committed_change = json.loads(connector.create_commit.call_args.args[1])["change"][-1]
+        assert committed_change["identity"]["@id"] == "literal-id"
+        assert committed_change["payload"] == {
+            "@type": "LiteralString",
+            "value": '"try\\\\to"',
+        }

--- a/tests/unit/sam/sysml2/classes/test_value_helper.py
+++ b/tests/unit/sam/sysml2/classes/test_value_helper.py
@@ -193,7 +193,7 @@ class TestValueHelperComplexExpressions:
         assert payload["value"] == '"say \\"hi\\""'
 
     def test_commit_literal_update_escapes_kerml_string(self, mocker):
-        """In-place LiteralString updates must KerML-escape like FeatureValue creates."""
+        """In-place LiteralString updates escape content without wrapping quotes."""
         helper = ValueHelper("_")
         connector = mocker.Mock()
         observer = mocker.Mock()
@@ -210,5 +210,5 @@ class TestValueHelperComplexExpressions:
         assert committed_change["identity"]["@id"] == "literal-id"
         assert committed_change["payload"] == {
             "@type": "LiteralString",
-            "value": '"try\\\\to"',
+            "value": "try\\\\to",
         }

--- a/tests/unit/sam/sysml2/observer/test_observer.py
+++ b/tests/unit/sam/sysml2/observer/test_observer.py
@@ -28,10 +28,10 @@ import pytest
 
 from ansys.sam.sysml2.builder.classes.project_impl import ProjectImpl
 from ansys.sam.sysml2.builder.sysml2_project_manager import SysML2ProjectManager
+from ansys.sam.sysml2.classes.sysml_element import SysMLElement
 from ansys.sam.sysml2.exception.connector_exception import BadRequestConnectionException
 from ansys.sam.sysml2.observer.observer import ModificationObserver
 from tests.unit.const import PROJECT_ID_1
-
 
 class TestObserverTransactional:
     """Transactional mode defers every change into a single commit at stop time.
@@ -98,6 +98,46 @@ class TestObserverTransactional:
 
         assert payload["change"][0]["identity"]["@id"] == "id"
         assert "payload" not in payload["change"][0]
+
+    def test_transactional_create_defers_list_links_after_creates(self, observer, connector, mocker):
+        """List links on a create are a separate update after all creates."""
+        commit_mock = mocker.patch.object(connector, "create_commit")
+        requirement_id = "req-id"
+        documentation_id = "doc-id"
+        documentation = SysMLElement(documentation_id)
+
+        observer.set_transactional_mode(True)
+        observer.notify(requirement_id, "@type", "RequirementUsage")
+        observer.notify(requirement_id, "declaredName", "MassLimit")
+        observer.notify(requirement_id, "owner", "bike-id")
+        observer.notify(documentation_id, "@type", "Documentation")
+        observer.notify(documentation_id, "body", "Shall not exceed 15 kg")
+        observer.list_notify(requirement_id, "documentation", [documentation])
+        observer.notify(requirement_id, "reqId", "REQ-001")
+        observer.set_transactional_mode(False)
+
+        changes = json.loads(commit_mock.call_args.args[1])["change"]
+        requirement_create, documentation_create, documentation_link = changes
+
+        assert requirement_create["identity"]["@id"] == requirement_id
+        assert requirement_create["payload"] == {
+            "@type": "RequirementUsage",
+            "declaredName": "MassLimit",
+            "owner": "bike-id",
+            "reqId": "REQ-001",
+        }
+        assert "documentation" not in requirement_create["payload"]
+
+        assert documentation_create["identity"]["@id"] == documentation_id
+        assert documentation_create["payload"] == {
+            "@type": "Documentation",
+            "body": "Shall not exceed 15 kg",
+        }
+
+        assert documentation_link["identity"]["@id"] == requirement_id
+        assert documentation_link["payload"] == {
+            "documentation": [{"@id": documentation_id}],
+        }
 
 
 class TestObserverImmediate:


### PR DESCRIPTION
## Summary
- Fix transactional commits: list links (e.g. `documentation`) are sent as a post-create update so derived `text` is restored in requirements e2e.
- Escape in-place `LiteralString` updates with KerML via `_adapt_value` (backslash e2e).