### PR TITLE
feat: forward includes_derived/includes_inherited on execute_query and element resolution

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -494,6 +494,11 @@ connector.get_all_elements(
 )
 ```
 
+The same kwargs are accepted by `execute_query` and forwarded to the ``/query-results``
+endpoint. When the project builder resolves unresolved IDs via queries, it passes the
+project's `includes_derived` / `includes_inherited` flags so missing elements match the
+bulk `/elements` payload.
+
 The same flags are available on the project manager / builder (`get_sysml_project`,
 `get_scripting_project`, `build_*`; defaults `True`).
 
@@ -510,8 +515,9 @@ project = manager.get_sysml_project(
 When `includes_derived=False`, PySAM rebuilds the main local derived collections from
 `ownedRelationship` (and from `inheritedMembership` when present), including for example
 `ownedElement`, `ownedMembership`, `ownedMember`, `ownedFeature`, `feature`,
-`inheritedFeature`, and requirement `text` from each attached `documentation.body`.
-Unresolved library references are not inserted into those collections.
+`inheritedFeature`, and requirement `text` from each attached `documentation.body`. This
+runs once over the whole project (bulk elements and any elements fetched later via
+queries). Unresolved library references are not inserted into those collections.
 
 ---
 

--- a/doc/changelog.d/295.added.md
+++ b/doc/changelog.d/295.added.md
@@ -1,0 +1,1 @@
+Forward includes_derived/includes_inherited on execute_query and element resolution

--- a/src/ansys/sam/sysml2/api/sysml2_api_connector.py
+++ b/src/ansys/sam/sysml2/api/sysml2_api_connector.py
@@ -141,7 +141,7 @@ class SysML2APIConnector(ABC):
         """Get all root elements of the project."""
 
     @abstractmethod
-    def execute_query(self, project_id: str, query: str) -> dict:
+    def execute_query(self, project_id: str, query: str, **kwargs) -> dict:
         """
         Send a query to the standard API using the connector.
 
@@ -151,6 +151,9 @@ class SysML2APIConnector(ABC):
             Project ID.
         query : str
             Query in JSON format.
+        **kwargs
+            Optional query parameters forwarded to the ``/query-results`` endpoint
+            (for example ``includes_derived`` / ``includes_inherited``).
 
         Returns
         -------

--- a/src/ansys/sam/sysml2/api/template_sysml2_api_connector.py
+++ b/src/ansys/sam/sysml2/api/template_sysml2_api_connector.py
@@ -192,14 +192,7 @@ class TemplateSysML2APIConnector(SysML2APIConnector):
         http_request = self._build_http_request(
             endpoint=f"/projects/{project_id}/commits/head/elements"
         )
-        if kwargs:
-            from ansys.sam.sysml2.tools.name_utils import NameUtils
-
-            params = {}
-            for key, value in kwargs.items():
-                param_key = NameUtils.snake_to_camel(key)
-                params[param_key] = str(value).lower() if isinstance(value, bool) else value
-            http_request.params = params
+        self._set_query_params(http_request, kwargs)
         return self._send_request(
             http_request=http_request,
             call=requests.get,
@@ -248,7 +241,7 @@ class TemplateSysML2APIConnector(SysML2APIConnector):
         )
         return self._send_request(http_request=http_request, call=requests.get)
 
-    def execute_query(self, project_id: str, query: str) -> dict:
+    def execute_query(self, project_id: str, query: str, **kwargs) -> dict:
         """
         Send a query to the standard API using the connector.
 
@@ -258,6 +251,9 @@ class TemplateSysML2APIConnector(SysML2APIConnector):
             ID of the project.
         query : str
             Query in JSON format.
+        **kwargs
+            Optional query parameters forwarded to the ``/query-results`` endpoint
+            (for example ``includes_derived`` / ``includes_inherited``).
 
         Returns
         -------
@@ -266,6 +262,7 @@ class TemplateSysML2APIConnector(SysML2APIConnector):
         """
         http_request = self._build_http_request(endpoint=f"/projects/{project_id}/query-results")
         http_request.json_body = json.loads(query)
+        self._set_query_params(http_request, kwargs)
         return self._send_request(http_request=http_request, call=requests.post)
 
     def create_commit(self, project_id: str, commit: str) -> dict:
@@ -273,6 +270,19 @@ class TemplateSysML2APIConnector(SysML2APIConnector):
         http_request = self._build_http_request(endpoint=f"/projects/{project_id}/commit")
         http_request.json_body = json.loads(commit)
         return self._send_request(http_request=http_request, call=requests.post)
+
+    @staticmethod
+    def _set_query_params(http_request: HttpRequest, kwargs: dict) -> None:
+        """Forward optional kwargs as camelCase HTTP query parameters."""
+        if not kwargs:
+            return
+        from ansys.sam.sysml2.tools.name_utils import NameUtils
+
+        params = {}
+        for key, value in kwargs.items():
+            param_key = NameUtils.snake_to_camel(key)
+            params[param_key] = str(value).lower() if isinstance(value, bool) else value
+        http_request.params = params
 
     def _build_http_request(self, endpoint: str) -> HttpRequest:
         """

--- a/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
+++ b/src/ansys/sam/sysml2/builder/sysml2_project_builder.py
@@ -296,7 +296,12 @@ class SysML2ProjectBuilder:
         else:
             cp = PrimitiveConstraint(property_name="@id", value=next(iter(missing_elements)))
         query.where = cp
-        return self._connector.execute_query(project._id, query.to_json())
+        return self._connector.execute_query(
+            project._id,
+            query.to_json(),
+            includes_derived=project._includes_derived,
+            includes_inherited=project._includes_inherited,
+        )
 
     def _resolve_inherited_link(self, project: Project | ScriptingProject):
         """Refresh per-element hash map and owned-name set; proxies are created lazily on access."""

--- a/tests/unit/mocked_connector.py
+++ b/tests/unit/mocked_connector.py
@@ -230,12 +230,15 @@ class MockedSysML2APIConnector(SysML2APIConnector):
                 roots[element["@id"]] = element
         return list(roots.values())
 
-    def execute_query(self, project_id: str, query: str) -> dict:
+    def execute_query(self, project_id: str, query: str, **kwargs) -> dict:
         """Return the library elements matching the query's @id constraints."""
         if project_id not in self._projects:
             raise ProjectNotFoundException(f"Project {project_id} not found")
         wanted = self._extract_ids(json.loads(query))
-        return [el for el in self._load_library_elements(project_id) if el.get("@id") in wanted]
+        elements = [el for el in self._load_library_elements(project_id) if el.get("@id") in wanted]
+        if not kwargs.get("includes_derived", True):
+            elements = self._strip_derived_properties(elements)
+        return elements
 
     def create_commit(self, project_id: str, commit: str) -> dict:
         """Return a realistic CommitDto response."""

--- a/tests/unit/sam/sysml2/api/test_ansys_sysml2_api_connector.py
+++ b/tests/unit/sam/sysml2/api/test_ansys_sysml2_api_connector.py
@@ -92,3 +92,22 @@ class TestAnsysSysML2APIConnector:
             "includesDerived": "false",
             "includesInherited": "false",
         }
+
+    def test_execute_query_query_params(self, connector, mocker):
+        mock_post = mocker.patch(
+            "requests.post",
+            return_value=_MockResponse(200, content=b"[]"),
+        )
+
+        connector.execute_query(
+            "project-1",
+            "{}",
+            includes_derived=False,
+            includes_inherited=False,
+        )
+
+        mock_post.assert_called_once()
+        assert mock_post.call_args.kwargs["params"] == {
+            "includesDerived": "false",
+            "includesInherited": "false",
+        }

--- a/tests/unit/sam/sysml2/builder/test_sysml2_project_builder.py
+++ b/tests/unit/sam/sysml2/builder/test_sysml2_project_builder.py
@@ -112,3 +112,19 @@ class TestSysML2ProjectBuilderIncludesFlags:
         first_call_kwargs = get_all_elements.call_args_list[0].kwargs
         assert first_call_kwargs["includes_derived"] is False
         assert first_call_kwargs["includes_inherited"] is False
+
+    def test_get_missing_passes_includes_flags(self, connector, mocker):
+        builder = SysML2ProjectBuilder(connector)
+        project = builder.build_sysml_project(
+            PROJECT_ID_1,
+            includes_derived=False,
+            includes_inherited=False,
+        )
+        execute_query = mocker.patch.object(connector, "execute_query", return_value=[])
+
+        builder._get_missing(project, {"missing-id"})
+
+        execute_query.assert_called()
+        call_kwargs = execute_query.call_args.kwargs
+        assert call_kwargs["includes_derived"] is False
+        assert call_kwargs["includes_inherited"] is False


### PR DESCRIPTION
Forward includes_derived / includes_inherited through execute_query and unresolved-element resolution so query results match the project load flags.