### PR TITLE
ci: allow manual trigger of private PyPI release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
     needs: [package, update-changelog]
     runs-on: [self-hosted, Windows, ansys-network, artifactory]
     environment: release-private-pypi
-    if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
+    if: ${{ (github.event_name == 'push' && contains(github.ref, 'refs/tags')) || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: "Download packages artifact"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/doc/changelog.d/366.maintenance.md
+++ b/doc/changelog.d/366.maintenance.md
@@ -1,0 +1,1 @@
+Allow manual trigger of private PyPI release workflow


### PR DESCRIPTION
## Description
Allows the `release-private-pypi` job to be triggered manually via `workflow_dispatch`, in addition to the existing tag-push trigger.

This will be used to push wheels from (pre-)releases to the private PyPI on demand, notably to backfill older versions.

## Issue linked
Closes #365